### PR TITLE
Fix margins which caused problems in some screen sizes

### DIFF
--- a/src/login/styles/ylitse.css
+++ b/src/login/styles/ylitse.css
@@ -242,7 +242,7 @@ input[type='button'] {
   font-weight: 700;
   align-self: center;
   position: absolute;
-  bottom: 12vh;
+  bottom: 125px;
   left: 50%;
   transform: translateX(-50%);
   transition: background-color 300ms forwards, color 300ms forwards;
@@ -445,6 +445,6 @@ input[type='submit'] {
   }
 
   form[name='login'] {
-    margin-top: -7vh;
+    margin-top: 30px;
   }
 }


### PR DESCRIPTION
# Description

Some screen sizes caused problems because "vh margins". This pr fixes the problems by replacing the problematic vh margins by pixels.

For example 

![image](https://user-images.githubusercontent.com/1396100/178471655-9ba606a0-46da-416a-a470-0197595636d5.png)

## Why was the change made?

Some screen sizes were broken.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Existing tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
