### PR TITLE
Validate inputs after every keyup, and do it only to inputs already touched

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -2,7 +2,7 @@
 /// <reference types="cypress" />
 
 Cypress.Commands.add('fillInput', (id: string, value: string): void => {
-  cy.get(`input[id="${id}"]`).type(value).blur();
+  cy.get(`input[id="${id}"]`).type(value);
 });
 
 Cypress.Commands.add(

--- a/cypress/tests/register.cy.ts
+++ b/cypress/tests/register.cy.ts
@@ -1,6 +1,6 @@
 describe('register', () => {
   const clear = (input: string): void => {
-    cy.get(`input[id="${input}"]`).clear().blur();
+    cy.get(`input[id="${input}"]`).clear();
   };
 
   const click = (button: string): void => {

--- a/src/register/index.html
+++ b/src/register/index.html
@@ -46,7 +46,7 @@
             maxlength="100"
             minlength="2"
             pattern=".{2,100}"
-            onChange="checkForm()"
+            onkeyup="checkInput('username')"
             autofocus
             required
           />
@@ -86,7 +86,7 @@
             maxlength="100"
             minlength="8"
             pattern=".{8,100}"
-            onChange="checkForm()"
+            onkeyup="checkInput('password')"
             required
           />
           <label class="error-message">
@@ -118,7 +118,7 @@
             name="password-confirmation"
             type="password"
             maxlength="100"
-            onChange="checkForm()"
+            onkeyup="checkInput('password-confirmation')"
             required
           />
           <label class="error-message">
@@ -133,7 +133,7 @@
             name="email"
             type="email"
             maxlength="200"
-            onChange="checkForm()"
+            onkeyup="checkInput('email')"
           />
           <label class="error-message">
             <img src="/static/icons/warning.svg" />
@@ -164,7 +164,7 @@
             maxlength="30"
             minlength="2"
             pattern=".{2,30}"
-            onChange="checkForm()"
+            onkeyup="checkInput('display-name')"
             required
           />
           <label class="error-message">
@@ -210,7 +210,7 @@
             <input
               id="required-age"
               type="checkbox"
-              onChange="checkForm()"
+              onchange="checkForm()"
               required
             />
             <span class="slider"></span>
@@ -224,7 +224,7 @@
             <input
               id="privacy-consent"
               type="checkbox"
-              onChange="checkForm()"
+              onchange="checkForm()"
               required
             />
             <span class="slider"></span>

--- a/src/register/index.js
+++ b/src/register/index.js
@@ -91,6 +91,8 @@ const toggleInput = id => {
   }
 };
 
+const getInputValue = id => document.getElementById(id).value;
+
 const getErrorMessage = id =>
   document.getElementById(`${id}-field`).querySelector('.error-message');
 
@@ -99,12 +101,39 @@ const hideAllUsernameErrors = () =>
     .querySelectorAll('span')
     .forEach(message => (message.style.display = 'none'));
 
-const changeUsernameError = errorId => {
+const changeUsernameError = id => {
   hideAllUsernameErrors();
-  document.getElementById(errorId).style.display = 'flex';
+  document.getElementById(id).style.display = 'flex';
+};
+
+const checkForError = async inputs => {
+  for (const input of inputs) {
+    if (!input.checkValidity()) return true; // Input value is invalid
+    if (input.id === 'username') {
+      try {
+        const usernameIsFree = await isUsernameFree(input.value);
+        if (!usernameIsFree) return true; // Username is taken
+      } catch (error) {
+        return true; // Username validation failed
+      }
+    }
+    if (input.id === 'password-confirmation') {
+      if (input.value !== getInputValue('password')) {
+        return true; // Passwords don't match
+      }
+    }
+  }
+};
+
+const checkForm = async () => {
+  const inputs = document.querySelectorAll('input');
+  const formError = await checkForError(inputs);
+  // Disable submit button if an error is found
+  document.getElementById('submit').disabled = formError;
 };
 
 const displayError = input => {
+  document.getElementById('submit').disabled = true;
   input.classList.remove('input-checkmark');
   input.classList.add('error-border');
   document.querySelector(`label[for=${input.id}]`).classList.add('error-color');
@@ -117,72 +146,61 @@ const removeError = input => {
     .querySelector(`label[for=${input.id}]`)
     .classList.remove('error-color');
   getErrorMessage(input.id).style.display = 'none';
+  checkForm();
 };
 
-const checkForm = async () => {
-  let formError = false;
-  const inputs = document
-    .getElementById('register-form')
-    .querySelectorAll('input');
+const validatePasswordConfirmation = () => {
+  const password = document.getElementById('password');
+  const confirmation = document.getElementById('password-confirmation');
+  password.value === confirmation.value
+    ? removeError(confirmation) // Passwords match
+    : displayError(confirmation); // Passwords don't match
+  if (confirmation.value.length >= 8)
+    confirmation.classList.add('input-checkmark');
+};
 
-  // Validate all inputs
-  for (const input of inputs) {
-    if (input.id === 'username') {
-      if (input.checkValidity()) {
-        // Username is long enough
-        const username = document.getElementById(input.id).value;
-        try {
-          const usernameIsFree = await isUsernameFree(username);
-          if (usernameIsFree) {
-            hideAllUsernameErrors();
-            removeError(input);
-            input.classList.add('input-checkmark');
-          } else {
-            // Username is taken
-            formError = true;
-            changeUsernameError('taken-message');
-            displayError(input);
-          }
-        } catch (error) {
-          // Username validation failed
-          formError = true;
-          changeUsernameError('try-again-message');
+const validateInput = input => {
+  if (input.checkValidity()) {
+    // Input value is valid
+    removeError(input);
+    if (input.id !== 'email' || input.value)
+      // Empty email gets no checkmark
+      input.classList.add('input-checkmark');
+  } else {
+    // Input value is invalid
+    displayError(input);
+  }
+};
+
+const checkInput = async id => {
+  const input = document.getElementById(id);
+  if (input.id === 'username') {
+    if (!input.checkValidity()) {
+      // Username is too short
+      changeUsernameError('too-short-message');
+      displayError(input);
+    } else {
+      // Username is long enough
+      try {
+        const usernameIsFree = await isUsernameFree(input.value);
+        if (usernameIsFree) {
+          hideAllUsernameErrors();
+          removeError(input);
+          input.classList.add('input-checkmark');
+        } else {
+          // Username is taken
+          changeUsernameError('taken-message');
           displayError(input);
         }
-      } else {
-        // Username is too short
-        formError = true;
-        changeUsernameError('too-short-message');
-        displayError(input);
-      }
-    } else if (input.id === 'password-confirmation') {
-      if (input.value === document.getElementById('password').value) {
-        // Passwords match
-        removeError(input);
-        if (input.value.length >= 8) {
-          input.classList.add('input-checkmark');
-        }
-      } else {
-        // Passwords don't match
-        formError = true;
-        displayError(input);
-      }
-    } else if (input.checkValidity()) {
-      // Input value is valid
-      if (input.type !== 'checkbox') {
-        removeError(input);
-        if (input.id !== 'email' || input.value)
-          // Empty email gets no checkmark
-          input.classList.add('input-checkmark');
-      }
-    } else {
-      // Input value is invalid
-      formError = true;
-      if (input.type !== 'checkbox') {
+      } catch (error) {
+        // Username validation failed
+        changeUsernameError('try-again-message');
         displayError(input);
       }
     }
+  } else {
+    if (input.id !== 'password-confirmation') validateInput(input);
+    if (input.id === 'password' || input.id === 'password-confirmation')
+      validatePasswordConfirmation();
   }
-  // Disable submit button if any input is invalid
-  document.getElementById('submit').disabled = formError;
 };


### PR DESCRIPTION
Fixes: 
[Improve input field validation](https://trello.com/c/ElZidpPb/713-improve-input-field-validation)
[Registration page inputs should show errors ONLY if they have been visited](https://trello.com/c/Poi4Hqu6/709-registration-page-inputs-should-show-errors-only-if-they-have-been-visited)

## Why was the change made?

To improve usability.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unittest
- [x] Cypress e2e -tests

# Caveats?

Does this introduce new warnings or are linter rules suppressed? Why? Is only manual testing applicable for this feature? Is there something special that the reviewer should take into account?

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
