### PR TITLE
Fix password confirmation error

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -9,7 +9,7 @@ Cypress.Commands.add('switchLanguage', (language: string): void => {
 });
 
 Cypress.Commands.add('fillInput', (id: string, value: string): void => {
-  cy.get(`input[id="${id}"]`).type(value);
+  cy.get(`input[id="${id}"]`).type(value).blur();
 });
 
 Cypress.Commands.add(

--- a/cypress/tests/register.cy.ts
+++ b/cypress/tests/register.cy.ts
@@ -1,6 +1,6 @@
 describe('register', () => {
   const clear = (input: string): void => {
-    cy.get(`input[id="${input}"]`).clear();
+    cy.get(`input[id="${input}"]`).clear().blur();
   };
 
   const click = (button: string): void => {

--- a/src/register/index.html
+++ b/src/register/index.html
@@ -66,7 +66,7 @@
             maxlength="100"
             minlength="2"
             pattern=".{2,100}"
-            onkeyup="checkInput('username')"
+            onblur="checkInput('username')"
             required />
           <label class="error-message">
             <img src="/static/icons/warning.svg" />
@@ -111,7 +111,7 @@
             maxlength="100"
             minlength="8"
             pattern=".{8,100}"
-            onkeyup="checkInput('password')"
+            onblur="checkInput('password')"
             required />
           <label class="error-message">
             <img src="/static/icons/warning.svg" />
@@ -146,7 +146,7 @@
             name="password-confirmation"
             type="password"
             maxlength="100"
-            onkeyup="checkInput('password-confirmation')"
+            onblur="checkInput('password-confirmation')"
             required />
           <label class="error-message">
             <img src="/static/icons/warning.svg" />
@@ -160,7 +160,7 @@
             name="email"
             type="email"
             maxlength="200"
-            onkeyup="checkInput('email')" />
+            onblur="checkInput('email')" />
           <label class="error-message">
             <img src="/static/icons/warning.svg" />
             <span localization-key="emailError">
@@ -188,7 +188,7 @@
             maxlength="30"
             minlength="2"
             pattern=".{2,30}"
-            onkeyup="checkInput('display-name')"
+            onblur="checkInput('display-name')"
             required />
           <label class="error-message">
             <img src="/static/icons/warning.svg" />

--- a/src/register/index.js
+++ b/src/register/index.js
@@ -167,11 +167,15 @@ const validatePasswordConfirmation = () => {
 
   const password = document.getElementById('password');
   const confirmation = document.getElementById('password-confirmation');
-  password.value === confirmation.value
-    ? removeError(confirmation) // Passwords match
-    : displayError(confirmation); // Passwords don't match
-  if (confirmation.value.length >= 8)
-    confirmation.classList.add('input-checkmark');
+  if (password.value === confirmation.value) {
+    // Passwords match
+    removeError(confirmation);
+    if (confirmation.value.length >= 8)
+      confirmation.classList.add('input-checkmark');
+  } else {
+    // Passwords don't match
+    displayError(confirmation);
+  }
 };
 
 const validateInput = input => {

--- a/src/register/index.js
+++ b/src/register/index.js
@@ -64,6 +64,8 @@
   });
 })(window, document);
 
+let passwordConfirmationHasBeenAccessed = false;
+
 const isUsernameFree = async username => {
   const response = await fetch('/api/search?login_name=' + username, {
     method: 'HEAD',
@@ -161,6 +163,8 @@ const removeError = input => {
 };
 
 const validatePasswordConfirmation = () => {
+  passwordConfirmationHasBeenAccessed = true;
+
   const password = document.getElementById('password');
   const confirmation = document.getElementById('password-confirmation');
   password.value === confirmation.value
@@ -210,8 +214,10 @@ const checkInput = async id => {
       }
     }
   } else {
-    if (input.id !== 'password-confirmation') validateInput(input);
-    if (input.id === 'password' || input.id === 'password-confirmation')
+    if (input.id === 'password-confirmation') validatePasswordConfirmation();
+    else validateInput(input);
+
+    if (input.id === 'password' && passwordConfirmationHasBeenAccessed)
       validatePasswordConfirmation();
   }
 };


### PR DESCRIPTION
# Description

Password confirmation error is shown only after the field has been accessed. Input field validations are triggered on blur instead of keyup so that when using keyboard navigation, the error is displayed after the field is left and not right when it's accessed. 

Fixes [Password confirmation input should show error ONLY if it has been visited](https://trello.com/c/ZgJIq0nU/715-password-confirmation-input-should-show-error-only-if-it-has-been-visited)

## Why was the change made?

This improves usability and UX.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unittest
- [ ] Cypress e2e -tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
