### PR TITLE
Open latest chat on chat page + Sort chats by latest message timestamp

### DIFF
--- a/src/features/Chat/chatSlice.ts
+++ b/src/features/Chat/chatSlice.ts
@@ -239,7 +239,7 @@ export const selectChats = createSelector(
       .sort(sortChats),
 );
 
-export const selectAnyChats = createSelector(
+export const selectChatsExist = createSelector(
   selectChatState,
   ({ chats }) => Object.values(chats).length > 0,
 );
@@ -249,30 +249,20 @@ export const selectActiveChat = createSelector(
   ({ activeChatId, chats }) => (activeChatId ? chats[activeChatId] : null),
 );
 
-export const selectIsActiveChat = createSelector(
+export const selectActiveChatExists = createSelector(
   selectChatState,
   ({ activeChatId, chats }) => Boolean(activeChatId && chats[activeChatId]),
 );
 
 // Returns most recent unread chat, or the most recent if all are read
-export const selectDefaultChat = createSelector(
-  selectChatState,
-  ({ activeFolder, chats }) => {
-    const sortedChats = Object.values(chats)
-      .filter(chat => chat.status === activeFolder)
-      .sort(sortChats);
+export const selectDefaultChat = createSelector(selectChats, chats => {
+  const unreadChats = chats.filter(chat => {
+    if (chat.status !== 'ok') return false;
+    return chat.messages.some(message => !message.opened);
+  });
 
-    const unreadChats = sortedChats.filter(chat => {
-      if (chat.status !== 'ok') return false;
-      for (const message of chat.messages) {
-        if (!message.opened) return true;
-      }
-      return false;
-    });
-
-    return unreadChats[0] ?? sortedChats[0];
-  },
-);
+  return unreadChats[0] ?? chats[0];
+});
 
 export const selectBuddyMessages = (buddyId: string) =>
   createSelector(

--- a/src/features/Chat/chatSlice.ts
+++ b/src/features/Chat/chatSlice.ts
@@ -219,6 +219,18 @@ export const selectChats = createSelector(
     Object.values(chats)
       .filter(chat => chat.status === activeFolder)
       .sort((a, b) => {
+        const aHasNoMessages = a.messages.length === 0;
+        const bHasNoMessages = b.messages.length === 0;
+
+        // If both chats have no messages, they are considered equal
+        if (aHasNoMessages && bHasNoMessages) return 0;
+
+        // If only a has no messages, it should come first
+        if (aHasNoMessages) return -1;
+
+        // If only b has no messages, it should come first
+        if (bHasNoMessages) return 1;
+
         const mostRecentA = sortMessagesByDateDescending(a.messages)[0];
         const mostRecentB = sortMessagesByDateDescending(b.messages)[0];
         return compareMessagesByTimeCreated(mostRecentA, mostRecentB);

--- a/src/features/Chat/chatSlice.ts
+++ b/src/features/Chat/chatSlice.ts
@@ -204,9 +204,39 @@ const getNextParams = (
 
 const selectChatState = ({ chats }: RootState) => chats;
 
+export const selectChats = createSelector(
+  selectChatState,
+  ({ activeFolder, chats }) => {
+    const filtered = Object.keys(chats)
+      .map(buddyId => chats[buddyId])
+      .filter(chat => chat.status === activeFolder);
+    return filtered;
+  },
+);
+
+export const selectAnyChats = createSelector(
+  selectChatState,
+  ({ chats }) => Object.values(chats).length > 0,
+);
+
 export const selectActiveChat = createSelector(
   selectChatState,
   ({ activeChatId, chats }) => (activeChatId ? chats[activeChatId] : null),
+);
+
+export const selectIsActiveChat = createSelector(
+  selectChatState,
+  ({ activeChatId, chats }) => Boolean(activeChatId && chats[activeChatId]),
+);
+
+export const selectDefaultChat = createSelector(
+  selectChatState,
+  ({ chats }) => {
+    // Returns most recent unread chat, and the most recent if all are read
+    const keys = Object.keys(chats);
+    const firstKey = keys[0];
+    return chats[firstKey];
+  },
 );
 
 export const selectBuddyMessages = (buddyId: string) =>
@@ -227,16 +257,6 @@ export const selectBuddyMessages = (buddyId: string) =>
       };
     },
   );
-
-export const selectChats = createSelector(
-  selectChatState,
-  ({ activeFolder, chats }) => {
-    const filtered = Object.keys(chats)
-      .map(buddyId => chats[buddyId])
-      .filter(chat => chat.status === activeFolder);
-    return filtered;
-  },
-);
 
 export const selectHasUnreadMessages = createSelector(
   selectChatState,

--- a/src/features/Chat/chatSlice.ts
+++ b/src/features/Chat/chatSlice.ts
@@ -204,14 +204,25 @@ const getNextParams = (
 
 const selectChatState = ({ chats }: RootState) => chats;
 
+const compareMessagesByTimeCreated = (
+  messageA: AppMessage,
+  messageB: AppMessage,
+): number =>
+  new Date(messageB.created).getTime() - new Date(messageA.created).getTime();
+
+const sortMessagesByDateDescending = (messages: AppMessage[]): AppMessage[] =>
+  [...messages].sort(compareMessagesByTimeCreated);
+
 export const selectChats = createSelector(
   selectChatState,
-  ({ activeFolder, chats }) => {
-    const filtered = Object.keys(chats)
-      .map(buddyId => chats[buddyId])
-      .filter(chat => chat.status === activeFolder);
-    return filtered;
-  },
+  ({ activeFolder, chats }) =>
+    Object.values(chats)
+      .filter(chat => chat.status === activeFolder)
+      .sort((a, b) => {
+        const mostRecentA = sortMessagesByDateDescending(a.messages)[0];
+        const mostRecentB = sortMessagesByDateDescending(b.messages)[0];
+        return compareMessagesByTimeCreated(mostRecentA, mostRecentB);
+      }),
 );
 
 export const selectAnyChats = createSelector(

--- a/src/features/Chat/components/ActiveWindow/index.tsx
+++ b/src/features/Chat/components/ActiveWindow/index.tsx
@@ -1,12 +1,13 @@
-// Libraries
 import styled, { css } from 'styled-components';
 
-// Store and hooks
 import {
+  ChatBuddy,
   selectActiveChat,
   selectIsLoadingBuddyMessages,
+  selectDefaultChat,
+  setActiveChat,
 } from '@/features/Chat/chatSlice';
-import { useAppSelector } from '@/store';
+import { useAppDispatch, useAppSelector } from '@/store';
 import { useSendMessageMutation } from '@/features/Chat/chatPageApi';
 import { useGetLayoutMode } from '@/hooks/useGetLayoutMode';
 
@@ -26,7 +27,13 @@ import MessageList from './MessageList';
 
 const ActiveWindow = () => {
   const { isTablet } = useGetLayoutMode();
-  const chat = useAppSelector(selectActiveChat);
+  const dispatch = useAppDispatch();
+
+  const activeChat: ChatBuddy | null = useAppSelector(selectActiveChat);
+  const defaultChat: ChatBuddy | null = useAppSelector(selectDefaultChat);
+
+  const chat: ChatBuddy = activeChat ?? defaultChat;
+  dispatch(setActiveChat(chat.buddyId));
 
   const [sendMessage, { isLoading: isLoadingSendMessage }] =
     useSendMessageMutation();

--- a/src/features/Chat/components/ActiveWindow/index.tsx
+++ b/src/features/Chat/components/ActiveWindow/index.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import styled, { css } from 'styled-components';
 
 import {
@@ -31,7 +32,10 @@ const ActiveWindow = () => {
   const activeChat = useAppSelector(selectActiveChat);
   const defaultChat = useAppSelector(selectDefaultChat);
   const chat = activeChat ?? defaultChat;
-  dispatch(setActiveChat(chat.buddyId));
+
+  useEffect(() => {
+    dispatch(setActiveChat(chat.buddyId));
+  }, [chat.buddyId]);
 
   const [sendMessage, { isLoading: isLoadingSendMessage }] =
     useSendMessageMutation();

--- a/src/features/Chat/components/ActiveWindow/index.tsx
+++ b/src/features/Chat/components/ActiveWindow/index.tsx
@@ -1,7 +1,6 @@
 import styled, { css } from 'styled-components';
 
 import {
-  ChatBuddy,
   selectActiveChat,
   selectIsLoadingBuddyMessages,
   selectDefaultChat,
@@ -29,10 +28,9 @@ const ActiveWindow = () => {
   const { isTablet } = useGetLayoutMode();
   const dispatch = useAppDispatch();
 
-  const activeChat: ChatBuddy | null = useAppSelector(selectActiveChat);
-  const defaultChat: ChatBuddy | null = useAppSelector(selectDefaultChat);
-
-  const chat: ChatBuddy = activeChat ?? defaultChat;
+  const activeChat = useAppSelector(selectActiveChat);
+  const defaultChat = useAppSelector(selectDefaultChat);
+  const chat = activeChat ?? defaultChat;
   dispatch(setActiveChat(chat.buddyId));
 
   const [sendMessage, { isLoading: isLoadingSendMessage }] =

--- a/src/features/Chat/components/Menu/Item.tsx
+++ b/src/features/Chat/components/Menu/Item.tsx
@@ -1,5 +1,10 @@
 import { useAppSelector, useAppDispatch } from '@/store';
-import { selectBuddyMessages, setActiveChat } from '@/features/Chat/chatSlice';
+import {
+  selectActiveChat,
+  selectBuddyMessages,
+  selectDefaultChat,
+  setActiveChat,
+} from '@/features/Chat/chatSlice';
 
 import type { ChatBuddy } from '@/features/Chat/chatSlice';
 
@@ -23,7 +28,9 @@ export const MenuItem = ({ buddy }: Props) => {
     isLoading,
   } = useAppSelector(selectBuddyMessages(buddyId));
   const activeFolder = useAppSelector(state => state.chats.activeFolder);
-  const activeChatId = useAppSelector(state => state.chats.activeChatId);
+  const activeChat = useAppSelector(selectActiveChat);
+  const defaultChat = useAppSelector(selectDefaultChat);
+  const activeChatId = activeChat?.buddyId ?? defaultChat.buddyId;
 
   const dispatch = useAppDispatch();
   const openChat = () => dispatch(setActiveChat(buddyId));

--- a/src/features/Chat/index.tsx
+++ b/src/features/Chat/index.tsx
@@ -1,6 +1,6 @@
 import styled, { css } from 'styled-components';
 
-import { selectActiveChat } from './chatSlice';
+import { selectAnyChats, selectIsActiveChat } from './chatSlice';
 import { useGetLayoutMode } from '@/hooks/useGetLayoutMode';
 import { useAppSelector } from '@/store';
 
@@ -14,16 +14,19 @@ import WelcomeWindow from './components/WelcomeWindow';
 
 const Chat = () => {
   const { isTablet } = useGetLayoutMode();
-  const chat = useAppSelector(selectActiveChat);
+  const isActiveChat: boolean = useAppSelector(selectIsActiveChat);
+  const anyChats: boolean = useAppSelector(selectAnyChats);
 
   return (
     <PageWithTransition>
       {isTablet ? (
-        <PageContainer>{chat ? <ActiveWindow /> : <Menu />}</PageContainer>
+        <PageContainer>
+          {isActiveChat ? <ActiveWindow /> : <Menu />}
+        </PageContainer>
       ) : (
         <PageContainer isDesktop>
           <Menu />
-          {chat ? <ActiveWindow /> : <WelcomeWindow />}
+          {anyChats ? <ActiveWindow /> : <WelcomeWindow />}
         </PageContainer>
       )}
     </PageWithTransition>

--- a/src/features/Chat/index.tsx
+++ b/src/features/Chat/index.tsx
@@ -1,6 +1,6 @@
 import styled, { css } from 'styled-components';
 
-import { selectAnyChats, selectIsActiveChat } from './chatSlice';
+import { selectActiveChatExists, selectChatsExist } from './chatSlice';
 import { useGetLayoutMode } from '@/hooks/useGetLayoutMode';
 import { useAppSelector } from '@/store';
 
@@ -14,19 +14,19 @@ import WelcomeWindow from './components/WelcomeWindow';
 
 const Chat = () => {
   const { isTablet } = useGetLayoutMode();
-  const isActiveChat: boolean = useAppSelector(selectIsActiveChat);
-  const anyChats: boolean = useAppSelector(selectAnyChats);
+  const activeChatExists = useAppSelector(selectActiveChatExists);
+  const chatsExist = useAppSelector(selectChatsExist);
 
   return (
     <PageWithTransition>
       {isTablet ? (
         <PageContainer>
-          {isActiveChat ? <ActiveWindow /> : <Menu />}
+          {activeChatExists ? <ActiveWindow /> : <Menu />}
         </PageContainer>
       ) : (
         <PageContainer isDesktop>
           <Menu />
-          {anyChats ? <ActiveWindow /> : <WelcomeWindow />}
+          {chatsExist ? <ActiveWindow /> : <WelcomeWindow />}
         </PageContainer>
       )}
     </PageWithTransition>

--- a/src/features/HomePage/components/NewMessages.tsx
+++ b/src/features/HomePage/components/NewMessages.tsx
@@ -2,6 +2,9 @@ import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
+import { clearActiveChat } from '@/features/Chat/chatSlice';
+import { useAppDispatch } from '@/store';
+
 import NewMessagesImage from '@/static/img/new-messages.svg';
 import { palette } from '@/components/variables';
 import Text from '@/components/Text';
@@ -9,8 +12,13 @@ import { TextButton } from '@/components/Buttons';
 
 const NewMessages = () => {
   const { t } = useTranslation('home');
+  const dispatch = useAppDispatch();
   const navigate = useNavigate();
-  const navigateToChat = () => navigate('/chat');
+
+  const navigateToNewMessages = () => {
+    dispatch(clearActiveChat());
+    navigate('/chat');
+  };
 
   return (
     <Container>
@@ -19,7 +27,7 @@ const NewMessages = () => {
           {t('newMessages.title')}
         </Text>
         <Text color="white">{t('newMessages.text')}</Text>
-        <Button variant="outline" onClick={navigateToChat}>
+        <Button variant="outline" onClick={navigateToNewMessages}>
           {t('newMessages.button')}
         </Button>
       </TextContainer>


### PR DESCRIPTION
# Description

- Chats are sorted in descending order by most latest message timestamp.
- Navigating to the Chat page opens the latest chat with unread messages. If no chat has unread messages, the chat with the latest message is displayed.

Fixes:
- [Open latest chat on chat page](https://trello.com/c/TZiw0sDz/948-open-latest-chat-on-chat-page)
- [Sort chats by latest message timestamp](https://trello.com/c/ImDqc3di/951-sort-chats-by-latest-message-timestamp)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unittest
- [ ] Cypress e2e -tests

# Caveats?

Does this introduce new warnings or are linter rules suppressed? Why? Is only manual testing applicable for this feature? Is there something special that the reviewer should take into account?

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
