### PR TITLE
Improve message fetching

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,5 +55,9 @@ jobs:
       - name: Run E2E tests
         run: |
           ${{ github.workspace }}/.github/scripts/start-api &
+
+          export YLITSE_API_PASS=$(grep -oP '(?<=admin_password: ).*' ./ylitse-api/ylitse_conf/ylitse.conf)
+          export YLITSE_MFA_SECRET=$(grep -oP '(?<=admin_2fa: ).*' ./ylitse-api/ylitse_conf/ylitse.conf)
+
           npm run start &
           npm run test:e2e

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Project uses [git-hooks](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hook
 
 ## End-to-end tests
 
+Tests need `YLITSE_API_PASS` and `YLITSE_MFA_SECRET` environment-variables for admin-user that can setup the database for tests
+
 Run locally:
 
 1. Start Ylitse-API `YLITSE_POSTGRES_DATA= make run-gunicorn`

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'cypress';
+import 'dotenv/config';
 
 export default defineConfig({
   defaultCommandTimeout: 10000,
@@ -7,7 +8,13 @@ export default defineConfig({
   e2e: {
     baseUrl: 'http://localhost:8082',
     specPattern: 'cypress/tests/**/*.cy.{js,jsx,ts,tsx}',
+    setupNodeEvents(_on, config) {
+      config.env.apiUrl = process.env.YLITSE_API_URL;
+      config.env.apiUser = process.env.YLITSE_API_USER;
+      config.env.apiPass = process.env.YLITSE_API_PASS;
+      config.env.mfaSecret = process.env.YLITSE_MFA_SECRET;
+      return config;
+    },
   },
   viewportWidth: 1600,
-  viewPortHeight: 720,
 });

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -8,7 +8,14 @@ export default defineConfig({
   e2e: {
     baseUrl: 'http://localhost:8082',
     specPattern: 'cypress/tests/**/*.cy.{js,jsx,ts,tsx}',
-    setupNodeEvents(_on, config) {
+    setupNodeEvents(on, config) {
+      on('task', {
+        log(message) {
+          console.log(message);
+          return null;
+        },
+      });
+
       config.env.apiUrl = process.env.YLITSE_API_URL;
       config.env.apiUser = process.env.YLITSE_API_USER;
       config.env.apiPass = process.env.YLITSE_API_PASS;

--- a/cypress/fixtures/accounts.ts
+++ b/cypress/fixtures/accounts.ts
@@ -1,0 +1,101 @@
+export type Mentee = {
+  loginName: string;
+  displayName: string;
+  password: string;
+  email: string;
+  role: 'mentee';
+};
+export type Mentor = {
+  loginName: string;
+  displayName: string;
+  password: string;
+  email: string;
+  role: 'mentor';
+  birthYear: number;
+  phone: string;
+  story: string;
+  languages: Array<string>;
+  skills: Array<string>;
+  communication_channels: Array<string>;
+  gender: string;
+  region: string;
+  status_message?: string;
+  is_vacationing?: boolean;
+};
+
+const mentees: Array<Mentee> = [
+  {
+    loginName: 'mentee',
+    displayName: 'mentee_nick',
+    password: 'Menteementee!',
+    email: 'mentee@mentee.mentee',
+    role: 'mentee',
+  },
+  {
+    loginName: 'mentee1',
+    displayName: 'mentee_fiona',
+    password: 'Menteementee!',
+    email: 'mentee1@mentee.mentee',
+    role: 'mentee',
+  },
+  {
+    loginName: 'mentee2',
+    displayName: 'mentee_seppo',
+    password: 'Menteementee!',
+    email: 'mentee2@mentee.mentee',
+    role: 'mentee',
+  },
+];
+
+const mentors: Array<Mentor> = [
+  {
+    loginName: 'mentor',
+    displayName: 'mentor_paavo',
+    password: 'mentormentor',
+    email: 'mentor1@mentor.mentor',
+    birthYear: 1980,
+    phone: '555-1234',
+    story: 'my story',
+    languages: ['fi', 'se'],
+    skills: ['kimble', 'pictionary', 'chess'],
+    communication_channels: ['phone', 'email'],
+    gender: 'other',
+    region: 'Tampesteri',
+    status_message: 'On vacation 1.9.-20.9.',
+    role: 'mentor',
+  },
+  {
+    loginName: 'mentor1',
+    displayName: 'mentor_myy',
+    password: 'mentormentor2',
+    email: 'mentor2@mentor.mentor',
+    birthYear: 1982,
+    phone: '555-12342',
+    story: 'my story 2',
+    languages: ['fi', 'se'],
+    skills: ['champagne', 'steaks', 'wine'],
+    communication_channels: ['phone', 'email'],
+    gender: 'other',
+    region: 'Tampesteri',
+    role: 'mentor',
+  },
+  {
+    loginName: 'mentor3',
+    displayName: 'mentor3_nick',
+    password: 'mentormentor3',
+    email: 'mentor3@mentor.mentor',
+    birthYear: 1983,
+    phone: '555-12343',
+    story: 'my story',
+    languages: ['fi', 'se'],
+    skills: ['vim', 'c++', 'python'],
+    communication_channels: ['phone', 'email'],
+    gender: 'other',
+    region: 'Tampesteri',
+    is_vacationing: true,
+    status_message: 'Gone gardening',
+    role: 'mentor',
+  },
+];
+
+export const accounts = { mentees, mentors };

--- a/cypress/support/api.ts
+++ b/cypress/support/api.ts
@@ -1,0 +1,260 @@
+import type { Mentee, Mentor } from '../fixtures/accounts';
+import { generateToken } from 'node-2fa';
+
+const API_URL = Cypress.env('YLITSE_API_URL') || 'http://127.0.0.1:8080';
+const API_USER = Cypress.env('YLITSE_API_USER') || 'admin';
+const API_PASS =
+  Cypress.env('YLITSE_API_PASS') ||
+  '46b76c3a52e9863347177b36d6c7a2e4f7167db83eecdba4';
+const MFA_SECRET =
+  Cypress.env('YLITSE_MFA_SECRET') || 'D4U3VOMWH7B4E3CNHL6JD6CAI366M6PF';
+
+/**
+ * Get access_token for admin
+ */
+const adminAccessToken = () => {
+  return accessToken(API_USER, API_PASS, MFA_SECRET);
+};
+
+/**
+ * Get access_token
+ */
+const accessToken = (
+  login_name: string,
+  password: string,
+  mfaSecret?: string,
+) => {
+  const newSecret = generateToken(mfaSecret ?? '');
+
+  return cy
+    .request({
+      method: 'POST',
+      url: `${API_URL}/login`,
+      body: {
+        login_name,
+        password,
+        ...(newSecret && { mfa_token: newSecret.token }),
+      },
+    })
+    .then(response => {
+      return response.body.tokens.access_token;
+    });
+};
+
+/**
+ * Get users from API
+ */
+const getUsers = (access_token: string) => {
+  return cy
+    .request({
+      method: 'GET',
+      url: `${API_URL}/users`,
+      headers: {
+        Authorization: `Bearer ${access_token}`,
+      },
+    })
+    .then(response => {
+      return response.body.resources;
+    });
+};
+
+/**
+ * Makes HTTP API calls to delete all users except those with role 'admin'
+ */
+const deleteAccounts = () => {
+  return adminAccessToken().then(access_token => {
+    return getUsers(access_token).then(users => {
+      users.forEach((user: any) => {
+        if (user.role !== 'admin') {
+          cy.request({
+            method: 'DELETE',
+            url: `${API_URL}/accounts/${user.account_id}`,
+            headers: {
+              Authorization: `Bearer ${access_token}`,
+            },
+          });
+        }
+      });
+    });
+  });
+};
+
+/**
+ * Makes HTTP API calls to delete user
+ */
+const deleteAccount = (id: string) => {
+  return adminAccessToken().then(access_token => {
+    cy.request({
+      method: 'DELETE',
+      url: `${API_URL}/accounts/${id}`,
+      headers: {
+        Authorization: `Bearer ${access_token}`,
+      },
+    });
+  });
+};
+
+/**
+ * SignUp new mentee
+ */
+const signUpMentee = (mentee: Mentee) => {
+  return cy
+    .request({
+      method: 'POST',
+      url: `${API_URL}/accounts`,
+      body: {
+        password: mentee.password,
+        account: {
+          role: mentee.role,
+          login_name: mentee.loginName,
+          email: mentee.email,
+        },
+      },
+    })
+    .then(() => {
+      return accessToken(mentee.loginName, mentee.password).then(
+        access_token => {
+          const headers = {
+            Authorization: `Bearer ${access_token}`,
+          };
+
+          return cy
+            .request({
+              method: 'GET',
+              url: `${API_URL}/myuser`,
+              headers,
+            })
+            .then(response => {
+              const myuser = response.body;
+
+              return cy.request({
+                method: 'PUT',
+                url: `${API_URL}/users/${myuser.user.id}`,
+                headers,
+                body: {
+                  display_name: mentee.displayName,
+                  role: mentee.role,
+                  account_id: myuser.account.id,
+                  id: myuser.user.id,
+                },
+              });
+            });
+        },
+      );
+    });
+};
+
+/**
+ * SignUp new mentor
+ */
+const signUpMentor = (mentor: Mentor) => {
+  return adminAccessToken().then(admin_access_token => {
+    const admin_headers = {
+      Authorization: `Bearer ${admin_access_token}`,
+    };
+
+    return cy
+      .request({
+        method: 'POST',
+        url: `${API_URL}/accounts`,
+        headers: admin_headers,
+        body: {
+          password: mentor.password,
+          account: {
+            role: mentor.role,
+            login_name: mentor.loginName,
+            email: mentor.email,
+            phone: mentor.phone,
+          },
+        },
+      })
+      .then(() => {
+        return accessToken(mentor.loginName, mentor.password).then(
+          access_token => {
+            const headers = {
+              Authorization: `Bearer ${access_token}`,
+            };
+
+            return cy
+              .request({
+                method: 'GET',
+                url: `${API_URL}/myuser`,
+                headers,
+              })
+              .then(response => {
+                const myuser = response.body;
+
+                return cy
+                  .request({
+                    method: 'PUT',
+                    url: `${API_URL}/users/${myuser.user.id}`,
+                    headers,
+                    body: {
+                      display_name: mentor.displayName,
+                      role: mentor.role,
+                      account_id: myuser.account.id,
+                      id: myuser.user.id,
+                      active: true,
+                    },
+                  })
+                  .then(() => {
+                    return cy.request({
+                      method: 'PUT',
+                      url: `${API_URL}/mentors/${myuser.mentor.id}`,
+                      headers: admin_headers,
+                      body: {
+                        birth_year: mentor.birthYear,
+                        display_name: mentor.displayName,
+                        gender: mentor.gender,
+                        languages: mentor.languages,
+                        region: mentor.region,
+                        skills: mentor.skills,
+                        story: mentor.story,
+                        communication_channels: mentor.communication_channels,
+                        is_vacationing: mentor.is_vacationing,
+                        status_message: mentor.status_message,
+                        account_id: myuser.account.id,
+                        user_id: myuser.user.id,
+                        id: myuser.mentor.id,
+                      },
+                    });
+                  });
+              });
+          },
+        );
+      });
+  });
+};
+
+type Data = {
+  sender_id: string;
+  recipient_id: string;
+  content: string;
+  headers: Record<string, string>;
+};
+
+const sendMessage = ({ sender_id, recipient_id, content, headers }: Data) => {
+  return cy
+    .request({
+      method: 'POST',
+      url: `${API_URL}/users/${sender_id}/messages`,
+      headers: headers,
+      body: {
+        sender_id,
+        recipient_id,
+        content,
+        opened: false,
+      },
+    })
+    .then(response => {
+      return response.body;
+    });
+};
+
+export const api = {
+  signUpMentee,
+  signUpMentor,
+  deleteAccount,
+  deleteAccounts,
+  sendMessage,
+};

--- a/cypress/support/api.ts
+++ b/cypress/support/api.ts
@@ -1,13 +1,10 @@
 import type { Mentee, Mentor } from '../fixtures/accounts';
 import { generateToken } from 'node-2fa';
 
-const API_URL = Cypress.env('YLITSE_API_URL') || 'http://127.0.0.1:8080';
-const API_USER = Cypress.env('YLITSE_API_USER') || 'admin';
-const API_PASS =
-  Cypress.env('YLITSE_API_PASS') ||
-  '46b76c3a52e9863347177b36d6c7a2e4f7167db83eecdba4';
-const MFA_SECRET =
-  Cypress.env('YLITSE_MFA_SECRET') || 'D4U3VOMWH7B4E3CNHL6JD6CAI366M6PF';
+const API_URL = Cypress.env('apiUrl') || 'http://127.0.0.1:8080';
+const API_USER = Cypress.env('apiUrl') || 'admin';
+const API_PASS = Cypress.env('apiPass') || '';
+const MFA_SECRET = Cypress.env('mfaSecret') || '';
 
 /**
  * Get access_token for admin

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -20,7 +20,7 @@ Cypress.Commands.add(
     };
 
     cy.visit('/register/');
-    cy.fillInput('logi', username);
+    cy.fillInput('username', username);
     cy.fillInput('password', password);
     cy.fillInput('password-confirmation', password);
     cy.fillInput('display-name', 'exampleDisplayName');

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -20,7 +20,7 @@ Cypress.Commands.add(
     };
 
     cy.visit('/register/');
-    cy.fillInput('username', username);
+    cy.fillInput('logi', username);
     cy.fillInput('password', password);
     cy.fillInput('password-confirmation', password);
     cy.fillInput('display-name', 'exampleDisplayName');
@@ -43,11 +43,16 @@ Cypress.Commands.add(
   },
 );
 
+Cypress.Commands.add('findByText', (text: string, selector = '*') => {
+  cy.get(selector).contains(text);
+});
+
 declare namespace Cypress {
   interface Chainable {
     switchLanguage(language: string): Chainable<void>;
     fillInput(id: string, value: string): Chainable<void>;
     registerUser(username: string, password: string): Chainable<void>;
     loginUser(username: string, password: string): Chainable<void>;
+    findByText(text: string, selector?: string): Chainable<void>;
   }
 }

--- a/cypress/tests/chat.cy.ts
+++ b/cypress/tests/chat.cy.ts
@@ -140,10 +140,12 @@ describe('chat', () => {
         };
         const reciever = { id: mentorResponse.body.user_id };
 
-        // send messages to other user
-        for (let i = 1; i <= numberOfMessages; i++) {
-          api.sendMessage({ sender, reciever, content: `${message} ${i}!` });
-        }
+        api.sendMultipleMessage({
+          sender,
+          reciever,
+          content: message,
+          amountOfMessages: 20,
+        });
       });
     });
 
@@ -177,16 +179,12 @@ describe('chat', () => {
         };
         const reciever = { id: mentorResponse.body.user_id };
 
-        for (let i = 1; i <= numberOfMessages; i++) {
-          api.sendMessage({ sender, reciever, content: `${message} ${i}!` });
-          //   .then(response => {
-          //     cy.task(
-          //       'log',
-          //       `sent message ${i} with id:${response.id}, timestamp: ${response.created}`,
-          //     );
-          //   });
-          // cy.wait(1500);
-        }
+        api.sendMultipleMessage({
+          sender,
+          reciever,
+          content: message,
+          amountOfMessages: 20,
+        });
       });
     });
 

--- a/cypress/tests/chat.cy.ts
+++ b/cypress/tests/chat.cy.ts
@@ -177,14 +177,20 @@ describe('chat', () => {
         };
         const reciever = { id: mentorResponse.body.user_id };
 
-        // send messages to other user
         for (let i = 1; i <= numberOfMessages; i++) {
           api.sendMessage({ sender, reciever, content: `${message} ${i}!` });
+          //   .then(response => {
+          //     cy.task(
+          //       'log',
+          //       `sent message ${i} with id:${response.id}, timestamp: ${response.created}`,
+          //     );
+          //   });
+          // cy.wait(1500);
         }
       });
     });
 
-    cy.loginUser(mentee.loginName, mentee.password);
+    cy.loginUser(mentor.loginName, mentor.password);
 
     // go to chat-page
     cy.get('[href="/chat"]').click();
@@ -192,7 +198,7 @@ describe('chat', () => {
     // should scroll to last message
     cy.findByText(`${message} ${numberOfMessages}!`, 'p').should('be.visible');
 
-    // scroll-up, oldest message should be visible
+    // scroll-up oldest message should be visible
     cy.findByText(`${message} 1!`, 'p').scrollIntoView().should('be.visible');
   });
 });

--- a/cypress/tests/chat.cy.ts
+++ b/cypress/tests/chat.cy.ts
@@ -1,0 +1,84 @@
+import { accounts } from 'cypress/fixtures/accounts';
+import { api } from '../support/api';
+
+describe('chat', () => {
+  before(() => {
+    api.deleteAccounts();
+  });
+
+  beforeEach(() => {
+    cy.visit('/login/');
+  });
+
+  it('can start a conversation with mentor', () => {
+    const mentee = accounts.mentees[0];
+    api.signUpMentee(mentee);
+    const mentor = accounts.mentors[0];
+    api.signUpMentor(mentor);
+    cy.loginUser(mentee.loginName, mentee.password);
+
+    // go to mentors page
+    cy.get('[href="/mentors"]').click();
+    cy.contains('mentor_paavo').should('be.visible');
+
+    // send message
+    cy.findByText('Open card', 'button').scrollIntoView().click();
+    cy.findByText('Start conversation', 'button').click();
+    cy.get('textarea[placeholder*="Write your message here"]')
+      .click()
+      .type('Hello there');
+    cy.get('button[aria-label="send"]').click();
+
+    // log out
+    cy.get('[href="/logout"]').click();
+    // log in with mentor-user
+    cy.loginUser(mentor.loginName, mentor.password);
+
+    // message came
+    cy.get('[href="/chat"]').click();
+    cy.findByText("Hello there", "p").should('be.visible')
+  });
+
+  xit('can send message to existing conversation', () => {
+    const mentee = accounts.mentees[0];
+    api.signUpMentee(mentee);
+    const mentor = accounts.mentors[0];
+    api.signUpMentor(mentor);
+    // send message between users
+
+    cy.loginUser(mentee.loginName, mentee.password);
+
+    // go to chat-page
+    // send message
+    // log out
+    // log in with other-user
+    // message came
+  });
+
+  xit('will show unseen-messages-ball if all unread messages not visible', () => {
+    const mentee = accounts.mentees[0];
+    api.signUpMentee(mentee);
+    const mentor = accounts.mentors[0];
+    api.signUpMentor(mentor);
+    // send message between users
+
+    cy.loginUser(mentee.loginName, mentee.password);
+
+    // see unseen-message-ball
+    // go to chat-page
+    // unseen-message-ball-disappears
+  });
+
+  xit('will load all messages if multiple unseen', () => {
+    const mentee = accounts.mentees[0];
+    api.signUpMentee(mentee);
+    const mentor = accounts.mentors[0];
+    api.signUpMentor(mentor);
+    // send 30-messages to other user
+
+    cy.loginUser(mentee.loginName, mentee.password);
+
+    // go to chat-page
+    // scroll-fast-up, oldest message should be visible
+  });
+});

--- a/cypress/tests/chat.cy.ts
+++ b/cypress/tests/chat.cy.ts
@@ -2,12 +2,13 @@ import { accounts } from 'cypress/fixtures/accounts';
 import { api } from '../support/api';
 
 describe('chat', () => {
-  before(() => {
+  beforeEach(() => {
     api.deleteAccounts();
+    cy.visit('/login/');
   });
 
-  beforeEach(() => {
-    cy.visit('/login/');
+  afterEach(() => {
+    cy.get('[href="/logout"]').click();
   });
 
   it('can start a conversation with mentor', () => {
@@ -36,49 +37,162 @@ describe('chat', () => {
 
     // message came
     cy.get('[href="/chat"]').click();
-    cy.findByText("Hello there", "p").should('be.visible')
+    cy.findByText('Hello there', 'p').should('be.visible');
   });
 
-  xit('can send message to existing conversation', () => {
+  it('can send message to existing conversation', () => {
     const mentee = accounts.mentees[0];
-    api.signUpMentee(mentee);
     const mentor = accounts.mentors[0];
-    api.signUpMentor(mentor);
-    // send message between users
+    const message = 'I would like to talk to you';
+    const answer = 'How can I help you';
+    //eslint-disable-next-line @typescript-eslint/no-explicit-any
+    api.signUpMentee(mentee).then((menteeResponse: any) => {
+      //eslint-disable-next-line @typescript-eslint/no-explicit-any
+      api.signUpMentor(mentor).then((mentorResponse: any) => {
+        const sender = {
+          id: menteeResponse.body.id,
+          loginName: mentee.loginName,
+          password: mentee.password,
+        };
+        const reciever = { id: mentorResponse.body.user_id };
 
-    cy.loginUser(mentee.loginName, mentee.password);
+        // send message between users
+        api.sendMessage({
+          sender,
+          reciever,
+          content: message,
+        });
+      });
+    });
+
+    cy.loginUser(mentor.loginName, mentor.password);
 
     // go to chat-page
+    cy.get('[href="/chat"]').click();
+    cy.findByText(message, 'p').should('be.visible');
+
     // send message
-    // log out
-    // log in with other-user
+    cy.get('textarea[placeholder*="Write your message here"]')
+      .click()
+      .type(answer);
+    cy.get('button[aria-label="send"]').click();
+
+    // log in with original-user
+    cy.get('[href="/logout"]').click();
+    cy.loginUser(mentee.loginName, mentee.password);
+
     // message came
+    cy.get('[href="/chat"]').click();
+    cy.findByText(answer, 'p').should('be.visible');
   });
 
-  xit('will show unseen-messages-ball if all unread messages not visible', () => {
+  it('marks unseen messages seen', () => {
     const mentee = accounts.mentees[0];
-    api.signUpMentee(mentee);
     const mentor = accounts.mentors[0];
-    api.signUpMentor(mentor);
-    // send message between users
+    const message = 'I would like to talk to you';
+    //eslint-disable-next-line @typescript-eslint/no-explicit-any
+    api.signUpMentee(mentee).then((menteeResponse: any) => {
+      //eslint-disable-next-line @typescript-eslint/no-explicit-any
+      api.signUpMentor(mentor).then((mentorResponse: any) => {
+        const sender = {
+          id: menteeResponse.body.id,
+          loginName: mentee.loginName,
+          password: mentee.password,
+        };
+        const reciever = { id: mentorResponse.body.user_id };
 
-    cy.loginUser(mentee.loginName, mentee.password);
+        // send message between users
+        api.sendMessage({
+          sender,
+          reciever,
+          content: message,
+        });
+      });
+    });
+
+    cy.loginUser(mentor.loginName, mentor.password);
 
     // see unseen-message-ball
-    // go to chat-page
+    cy.get('div[aria-label="unseen-messages-dot"]').should('be.visible');
+    // go to chat-page and mark message unseen
+    cy.get('[href="/chat"]').click();
+    cy.findByText(message, 'p').should('be.visible');
+    cy.wait(1000);
+    cy.get('[href="/mentors"]').click();
+
     // unseen-message-ball-disappears
+    cy.get('div[aria-label="unseen-messages-dot"]').should('not.exist');
   });
 
-  xit('will load all messages if multiple unseen', () => {
+  it('wont mark unseen if not visible', () => {
     const mentee = accounts.mentees[0];
-    api.signUpMentee(mentee);
     const mentor = accounts.mentors[0];
-    api.signUpMentor(mentor);
-    // send 30-messages to other user
+    const message = 'Huzzah';
+    const numberOfMessages = 20;
+    //eslint-disable-next-line @typescript-eslint/no-explicit-any
+    api.signUpMentee(mentee).then((menteeResponse: any) => {
+      //eslint-disable-next-line @typescript-eslint/no-explicit-any
+      api.signUpMentor(mentor).then((mentorResponse: any) => {
+        const sender = {
+          id: menteeResponse.body.id,
+          loginName: mentee.loginName,
+          password: mentee.password,
+        };
+        const reciever = { id: mentorResponse.body.user_id };
+
+        // send messages to other user
+        for (let i = 1; i <= numberOfMessages; i++) {
+          api.sendMessage({ sender, reciever, content: `${message} ${i}!` });
+        }
+      });
+    });
+
+    cy.loginUser(mentor.loginName, mentor.password);
+
+    // go to chat-page
+    cy.get('[href="/chat"]').click();
+
+    // should scroll to last message
+    cy.findByText(`${message} ${numberOfMessages}!`, 'p').should('be.visible');
+    cy.wait(1000);
+    cy.get('[href="/mentors"]').click();
+
+    // see unseen-message-ball still
+    cy.get('div[aria-label="unseen-messages-dot"]').should('be.visible');
+  });
+
+  it('will load all messages if multiple unseen', () => {
+    const mentee = accounts.mentees[0];
+    const mentor = accounts.mentors[0];
+    const message = 'Huzzah';
+    const numberOfMessages = 20;
+    //eslint-disable-next-line @typescript-eslint/no-explicit-any
+    api.signUpMentee(mentee).then((menteeResponse: any) => {
+      //eslint-disable-next-line @typescript-eslint/no-explicit-any
+      api.signUpMentor(mentor).then((mentorResponse: any) => {
+        const sender = {
+          id: menteeResponse.body.id,
+          loginName: mentee.loginName,
+          password: mentee.password,
+        };
+        const reciever = { id: mentorResponse.body.user_id };
+
+        // send messages to other user
+        for (let i = 1; i <= numberOfMessages; i++) {
+          api.sendMessage({ sender, reciever, content: `${message} ${i}!` });
+        }
+      });
+    });
 
     cy.loginUser(mentee.loginName, mentee.password);
 
     // go to chat-page
-    // scroll-fast-up, oldest message should be visible
+    cy.get('[href="/chat"]').click();
+
+    // should scroll to last message
+    cy.findByText(`${message} ${numberOfMessages}!`, 'p').should('be.visible');
+
+    // scroll-up, oldest message should be visible
+    cy.findByText(`${message} 1!`, 'p').scrollIntoView().should('be.visible');
   });
 });

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -4,5 +4,6 @@
   },
   "exclude": ["src/**/*.test.tsx"],
   "extends": "../tsconfig.json",
-  "include": ["../node_modules/cypress"]
+  "include": ["../node_modules/cypress", "**/*.ts"],
+  "types": ["cypress"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "jest": "^28.1.1",
         "jest-environment-jsdom": "^28.1.1",
         "msw": "^0.47.4",
+        "node-2fa": "^2.0.3",
         "prettier": "^3.0.3",
         "react-test-renderer": "^18.2.0",
         "ts-loader": "^8.4.0",
@@ -3570,6 +3571,16 @@
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/notp": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/notp/-/notp-2.0.5.tgz",
+      "integrity": "sha512-ZsZS0PYUa6ZE4K3yOGerBvaxCp4ePf6ZmkFbPeilcqz2Ui/lmXox7KlRt7XZkXzqUgXhFLkc09ixyVmFLCU3gQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/parse5": {
@@ -12826,6 +12837,19 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/node-2fa": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/node-2fa/-/node-2fa-2.0.3.tgz",
+      "integrity": "sha512-PQldrOhjuoZyoydMvMSctllPN1ZPZ1/NwkEcgYwY9faVqE/OymxR+3awPpbWZxm6acLKqvmNqQmdqTsqYyflFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/notp": "^2.0.0",
+        "notp": "^2.0.3",
+        "thirty-two": "1.0.2",
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/node-fetch": {
       "version": "2.6.8",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.8.tgz",
@@ -12896,6 +12920,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/notp": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/notp/-/notp-2.0.3.tgz",
+      "integrity": "sha512-oBig/2uqkjQ5AkBuw4QJYwkEWa/q+zHxI5/I5z6IeP2NT0alpJFsP/trrfCC+9xOAgQSZXssNi962kp5KBmypQ==",
+      "dev": true,
+      "engines": {
+        "node": "> v0.6.0"
       }
     },
     "node_modules/npm-run-path": {
@@ -15409,6 +15442,15 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "peer": true
+    },
+    "node_modules/thirty-two": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/thirty-two/-/thirty-two-1.0.2.tgz",
+      "integrity": "sha512-OEI0IWCe+Dw46019YLl6V10Us5bi574EvlJEOcAkB29IzQ/mYD1A6RyNHLjZPiHCmuodxvgF6U+vZO1L15lxVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.2.6"
+      }
     },
     "node_modules/throttleit": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "copy-webpack-plugin": "^11.0.0",
         "css-loader": "^6.7.1",
         "cypress": "^13.4.0",
+        "dotenv": "^16.4.5",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-better-styled-components": "^1.1.2",
         "eslint-plugin-jest": "^27.2.1",
@@ -6822,6 +6823,19 @@
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/ecc-jsbn": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "copy-webpack-plugin": "^11.0.0",
     "css-loader": "^6.7.1",
     "cypress": "^13.4.0",
+    "dotenv": "^16.4.5",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-better-styled-components": "^1.1.2",
     "eslint-plugin-jest": "^27.2.1",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "jest": "^28.1.1",
     "jest-environment-jsdom": "^28.1.1",
     "msw": "^0.47.4",
+    "node-2fa": "^2.0.3",
     "prettier": "^3.0.3",
     "react-test-renderer": "^18.2.0",
     "ts-loader": "^8.4.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,7 +23,7 @@ const App = () => {
 
   useGetContactsQuery(userId ?? skipToken);
   useGetMessagesQuery(messageParams, {
-    pollingInterval: 5000,
+    pollingInterval: 2000,
   });
 
   return isAuthenticated ? (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import {
   useGetContactsQuery,
   useGetMessagesQuery,
 } from './features/Chat/chatPageApi';
-import { selectCurrentPollingParams } from './features/Chat/chatSlice';
+import { selectCurrentPollingParams } from './features/Chat/selectors';
 import { skipToken } from '@reduxjs/toolkit/dist/query';
 
 import Navigation from './features/Navigation';
@@ -23,7 +23,7 @@ const App = () => {
 
   useGetContactsQuery(userId ?? skipToken);
   useGetMessagesQuery(messageParams, {
-    pollingInterval: 5000,
+    pollingInterval: 30000,
   });
 
   return isAuthenticated ? (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,7 +23,7 @@ const App = () => {
 
   useGetContactsQuery(userId ?? skipToken);
   useGetMessagesQuery(messageParams, {
-    pollingInterval: 30000,
+    pollingInterval: 5000,
   });
 
   return isAuthenticated ? (

--- a/src/features/Authentication/userSlice.ts
+++ b/src/features/Authentication/userSlice.ts
@@ -1,9 +1,15 @@
 import { createSelector } from 'reselect';
 import { createSlice } from '@reduxjs/toolkit';
 
+<<<<<<< HEAD
 import { authenticationApi, UserRole } from './authenticationApi';
 import { RootState } from '@/store';
 import { selectChatsExist } from '../Chat/chatSlice';
+=======
+import type { RootState } from '@/store';
+import { type UserRole, authenticationApi } from './authenticationApi';
+import { selectChatsExist } from '../Chat/selectors';
+>>>>>>> b2935e3 (Split file to logical modules)
 
 type User = {
   active: boolean;

--- a/src/features/Authentication/userSlice.ts
+++ b/src/features/Authentication/userSlice.ts
@@ -1,15 +1,9 @@
 import { createSelector } from 'reselect';
 import { createSlice } from '@reduxjs/toolkit';
 
-<<<<<<< HEAD
-import { authenticationApi, UserRole } from './authenticationApi';
-import { RootState } from '@/store';
-import { selectChatsExist } from '../Chat/chatSlice';
-=======
 import type { RootState } from '@/store';
 import { type UserRole, authenticationApi } from './authenticationApi';
 import { selectChatsExist } from '../Chat/selectors';
->>>>>>> b2935e3 (Split file to logical modules)
 
 type User = {
   active: boolean;

--- a/src/features/Chat/chatPageApi.ts
+++ b/src/features/Chat/chatPageApi.ts
@@ -149,7 +149,9 @@ export const chatApi = createApi({
           messagesResponseCodec,
           { resources: [], contacts: [] },
           ({ resources, contacts }) => ({
-            messages: resources.map(toAppMessage(userId)),
+            messages: [...resources]
+              .map(toAppMessage(userId))
+              .sort(sortByCreated),
             buddies: toAppBuddies(contacts),
           }),
         ),

--- a/src/features/Chat/chatPageApi.ts
+++ b/src/features/Chat/chatPageApi.ts
@@ -2,7 +2,7 @@ import { createApi } from '@reduxjs/toolkit/query/react';
 import * as D from 'io-ts/Decoder';
 import { parseAndTransformTo, refreshingBaseQuery } from '@/utils/http';
 import { pipe } from 'fp-ts/lib/function';
-import { ChatBuddy, PollingParam } from './chatSlice';
+import type { ChatBuddy, PollingParam } from './mappers';
 import toast from 'react-hot-toast';
 import { t } from 'i18next';
 import {

--- a/src/features/Chat/components/ActiveWindow/Header/DesktopButtons.tsx
+++ b/src/features/Chat/components/ActiveWindow/Header/DesktopButtons.tsx
@@ -6,7 +6,8 @@ import { Button, IconButton, StatusButton } from '@/components/Buttons';
 import { DEFAULT_ICON_SIZE } from '@/components/variables';
 import Search from './Search';
 
-import type { ChatBuddy } from '@/features/Chat/chatSlice';
+// Types
+import type { ChatBuddy } from '@/features/Chat/mappers';
 import type { DialogVariant } from '../Dialogs';
 
 type Props = {

--- a/src/features/Chat/components/ActiveWindow/Header/TabletButtons.tsx
+++ b/src/features/Chat/components/ActiveWindow/Header/TabletButtons.tsx
@@ -3,16 +3,16 @@ import styled from 'styled-components';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+// Types
+import type { ChatBuddy } from '@/features/Chat/mappers';
+import type { DialogVariant } from '../Dialogs';
+
 // Variables
 import { HIGH_ROW_HEIGHT } from '@/features/Chat/constants';
 import { DEFAULT_ICON_SIZE, palette } from '@/components/variables';
 
 // Components
 import { Button, IconButton, StatusButton } from '@/components/Buttons';
-
-// Types
-import type { ChatBuddy } from '@/features/Chat/chatSlice';
-import type { DialogVariant } from '../Dialogs';
 
 type Props = {
   chat: ChatBuddy;

--- a/src/features/Chat/components/ActiveWindow/Header/index.tsx
+++ b/src/features/Chat/components/ActiveWindow/Header/index.tsx
@@ -1,8 +1,9 @@
 // Libraries
 import styled from 'styled-components';
 
-// Store and hooks
-import { clearActiveChat, type ChatBuddy } from '@/features/Chat/chatSlice';
+// Store and hooks, type ChatBuddy
+import type { ChatBuddy } from '@/features/Chat/mappers';
+import { clearActiveChat } from '@/features/Chat/chatSlice';
 import {
   selectMentorById,
   useGetMentorsQuery,

--- a/src/features/Chat/components/ActiveWindow/Message.tsx
+++ b/src/features/Chat/components/ActiveWindow/Message.tsx
@@ -36,13 +36,14 @@ export const Message = ({ folder, buddyId, message }: Props) => {
   const handleMarkSeen = () => {
     if (!userId) return;
 
-    console.log('NotOpened', message.content);
-    console.log('Visibility', isVisible);
-    // markSeen({ userId, message: toPutMessage(message, buddyId, userId) });
+    // console.log('NotOpened', message.content);
+    // console.log('Visibility', isVisible);
+    markSeen({ userId, message: toPutMessage(message, buddyId, userId) });
   };
 
   useEffect(() => {
-    if (!message.opened && isVisible) {
+    const shouldMarkUnseen = !message.isSent && !message.opened && isVisible;
+    if (shouldMarkUnseen) {
       handleMarkSeen();
     }
   }, [isVisible]);

--- a/src/features/Chat/components/ActiveWindow/Message.tsx
+++ b/src/features/Chat/components/ActiveWindow/Message.tsx
@@ -1,7 +1,8 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 import { useAppSelector } from '@/store';
 import { selectUserId } from '@/features/Authentication/userSlice';
+import { useIsVisible } from '@/hooks/useIsVisible';
 
 import {
   AppMessage,
@@ -29,24 +30,28 @@ type Props = {
 export const Message = ({ folder, buddyId, message }: Props) => {
   const [markSeen] = useMarkSeenMutation();
   const userId = useAppSelector(selectUserId);
+  const ref = useRef(null);
+  const isVisible = useIsVisible<HTMLDivElement>(ref);
 
   const handleMarkSeen = () => {
     if (!userId) return;
 
-    markSeen({ userId, message: toPutMessage(message, buddyId, userId) });
+    console.log('NotOpened', message.content);
+    console.log('Visibility', isVisible);
+    // markSeen({ userId, message: toPutMessage(message, buddyId, userId) });
   };
 
   useEffect(() => {
-    if (!message.opened) {
+    if (!message.opened && isVisible) {
       handleMarkSeen();
     }
-  }, []);
+  }, [isVisible]);
 
   const background =
     messageColors[folder][message.isSent ? 'sent' : 'received'];
 
   return (
-    <Container isSent={message.isSent}>
+    <Container isSent={message.isSent} isVisible={isVisible} ref={ref}>
       <Bubble background={background}>
         <Content>{message.content}</Content>
       </Bubble>
@@ -57,8 +62,9 @@ export const Message = ({ folder, buddyId, message }: Props) => {
   );
 };
 
-const Container = styled.div<{ isSent: boolean }>`
+const Container = styled.div<{ isSent: boolean; isVisible: boolean }>`
   align-items: ${({ isSent }) => (isSent ? 'flex-end' : 'flex-start')};
+  border: ${({ isVisible }) => `1px solid ${isVisible ? 'green' : 'red'}`};
   display: flex;
   flex-direction: column;
 `;

--- a/src/features/Chat/components/ActiveWindow/Message.tsx
+++ b/src/features/Chat/components/ActiveWindow/Message.tsx
@@ -36,8 +36,6 @@ export const Message = ({ folder, buddyId, message }: Props) => {
   const handleMarkSeen = () => {
     if (!userId) return;
 
-    // console.log('NotOpened', message.content);
-    // console.log('Visibility', isVisible);
     markSeen({ userId, message: toPutMessage(message, buddyId, userId) });
   };
 
@@ -65,7 +63,6 @@ export const Message = ({ folder, buddyId, message }: Props) => {
 
 const Container = styled.div<{ isSent: boolean; isVisible: boolean }>`
   align-items: ${({ isSent }) => (isSent ? 'flex-end' : 'flex-start')};
-  border: ${({ isVisible }) => `1px solid ${isVisible ? 'green' : 'red'}`};
   display: flex;
   flex-direction: column;
 `;

--- a/src/features/Chat/components/ActiveWindow/MessageField.tsx
+++ b/src/features/Chat/components/ActiveWindow/MessageField.tsx
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import type { ChatBuddy } from '@/features/Chat/mappers';
 import { selectUserId } from '@/features/Authentication/userSlice';
 import {
   toSendMessage,
@@ -14,8 +15,6 @@ import { IconButton } from '@/components/Buttons';
 import { palette } from '@/components/variables';
 import { ROW_HEIGHT, SHORT_ROW_HEIGHT } from '@/features/Chat/constants';
 import TextInput from '@/components/TextInput';
-
-import type { ChatBuddy } from '@/features/Chat/chatSlice';
 
 type Props = {
   chat: ChatBuddy;

--- a/src/features/Chat/components/ActiveWindow/MessageField.tsx
+++ b/src/features/Chat/components/ActiveWindow/MessageField.tsx
@@ -38,8 +38,6 @@ const MessageField = ({ chat }: Props) => {
     try {
       await sendMessage({ userId, message }).unwrap();
     } catch (error) {
-      console.error('Failed to send message:', error);
-      // TODO: Tässä voitaisiin näyttää virheviesti käyttäjälle.
       setIsLoadingNewMessage(false);
     }
   };

--- a/src/features/Chat/components/ActiveWindow/index.tsx
+++ b/src/features/Chat/components/ActiveWindow/index.tsx
@@ -5,8 +5,8 @@ import {
   selectActiveChat,
   selectIsLoadingBuddyMessages,
   selectDefaultChat,
-  setActiveChat,
-} from '@/features/Chat/chatSlice';
+} from '@/features/Chat/selectors';
+import { setActiveChat } from '@/features/Chat/chatSlice';
 import { useAppDispatch, useAppSelector } from '@/store';
 import { useSendMessageMutation } from '@/features/Chat/chatPageApi';
 import { useGetLayoutMode } from '@/hooks/useGetLayoutMode';

--- a/src/features/Chat/components/Menu/Item.tsx
+++ b/src/features/Chat/components/Menu/Item.tsx
@@ -3,10 +3,10 @@ import {
   selectActiveChat,
   selectBuddyMessages,
   selectDefaultChat,
-  setActiveChat,
-} from '@/features/Chat/chatSlice';
+} from '@/features/Chat/selectors';
+import { setActiveChat } from '@/features/Chat/chatSlice';
 
-import type { ChatBuddy } from '@/features/Chat/chatSlice';
+import type { ChatBuddy } from '@/features/Chat/mappers';
 
 import styled, { css } from 'styled-components';
 import { folderColors } from '@/features/Chat/constants';

--- a/src/features/Chat/components/Menu/Item.tsx
+++ b/src/features/Chat/components/Menu/Item.tsx
@@ -52,7 +52,9 @@ export const MenuItem = ({ buddy }: Props) => {
       <MentorInfo>
         <BuddyName>
           <Text variant="bold">{displayName}</Text>
-          {hasUnread && <Badge>{count}</Badge>}
+          {hasUnread && (
+            <UnseenDot aria-label="unseen-messages-dot">{count}</UnseenDot>
+          )}
         </BuddyName>
         {isLoading ? (
           <Spinner variant="tiny" isDark centered={false} />
@@ -103,7 +105,7 @@ const Message = styled(Text)`
   white-space: nowrap;
 `;
 
-const Badge = styled.div`
+const UnseenDot = styled.div`
   align-items: center;
   background-color: ${palette.blue2};
   border-radius: 50%;

--- a/src/features/Chat/components/Menu/index.tsx
+++ b/src/features/Chat/components/Menu/index.tsx
@@ -3,7 +3,7 @@ import styled, { css } from 'styled-components';
 import { useTranslation } from 'react-i18next';
 
 // Store and hooks
-import { selectChats } from '@/features/Chat/chatSlice';
+import { selectChats } from '@/features/Chat/selectors';
 import { useAppSelector } from '@/store';
 import { useGetLayoutMode } from '@/hooks/useGetLayoutMode';
 

--- a/src/features/Chat/index.tsx
+++ b/src/features/Chat/index.tsx
@@ -1,6 +1,6 @@
 import styled, { css } from 'styled-components';
 
-import { selectActiveChatExists, selectChatsExist } from './chatSlice';
+import { selectActiveChatExists, selectChatsExist } from './selectors';
 import { useGetLayoutMode } from '@/hooks/useGetLayoutMode';
 import { useAppSelector } from '@/store';
 

--- a/src/features/Chat/mappers.ts
+++ b/src/features/Chat/mappers.ts
@@ -1,0 +1,109 @@
+import type { AppMessage, MessageResponse, Buddy } from './chatPageApi';
+import { sortByCreated } from './chatPageApi';
+
+export type Conversation = {
+  name: string;
+  buddyId: string;
+};
+
+export type ChatBuddy = Buddy & {
+  messages: AppMessage[];
+};
+
+export type PollingParam =
+  | {
+      type: 'New';
+      previousMsgId: string;
+    }
+  | { type: 'OlderThan'; buddyId: string; messageId: string }
+  | { type: 'InitialMessages'; buddyIds: Array<string> };
+
+export const toNewBuddy = ({ name, buddyId }: Conversation): ChatBuddy => ({
+  displayName: name,
+  buddyId,
+  role: 'mentor',
+  status: 'ok',
+  messages: [],
+});
+
+export const createBuddyChunks = (
+  buddyIds: Array<string>,
+): Array<PollingParam> => {
+  const chunkSize = 40;
+  const amountOfBatches = Math.ceil(buddyIds.length / chunkSize);
+
+  return [...Array(amountOfBatches).keys()]
+    .map(index => buddyIds.slice(index * chunkSize, (index + 1) * chunkSize))
+    .map(chunk => ({ type: 'InitialMessages', buddyIds: chunk }));
+};
+
+export const mergeMessages = (
+  originalChats: Record<string, ChatBuddy>,
+  response: MessageResponse,
+) =>
+  response.buddies.reduce((chats, contact) => {
+    const newMessages = response.messages.filter(
+      ({ buddyId }) => buddyId === contact.buddyId,
+    );
+    const existingBuddy = originalChats[contact.buddyId];
+    const existingMessages = existingBuddy ? existingBuddy.messages : [];
+
+    return {
+      ...chats,
+      [contact.buddyId]: {
+        ...contact,
+        messages: existingMessages.concat(newMessages).sort(sortByCreated),
+      },
+    };
+  }, originalChats);
+
+export const getNextParams = (
+  pollingQueue: Array<PollingParam> | null,
+  previousMsgId: string,
+): Array<PollingParam> => {
+  const normalPoll = { type: 'New', previousMsgId } as PollingParam;
+  const params = pollingQueue?.filter((_p, i) => i !== 0);
+
+  if (params?.length === 0) {
+    return [normalPoll];
+  }
+
+  return params ?? [normalPoll];
+};
+
+export const getParamsForUnreadMessages = (
+  messages: Array<AppMessage>,
+  params: Array<PollingParam> | null,
+): Array<PollingParam> => {
+  if (!params || params?.length === 0) {
+    return [];
+  }
+
+  const param = params[0];
+  switch (param.type) {
+    case 'OlderThan': {
+      return getOlderThanParamsIfHasUnread(messages)(param.buddyId);
+    }
+
+    case 'InitialMessages': {
+      return param.buddyIds.flatMap(getOlderThanParamsIfHasUnread(messages));
+    }
+
+    default: {
+      return [];
+    }
+  }
+};
+
+export const getOlderThanParamsIfHasUnread =
+  (messages: Array<AppMessage>) =>
+  (buddyId: string): Array<PollingParam> => {
+    const buddyMessages = messages.filter(
+      message => message.buddyId === buddyId,
+    );
+    const hasUnread = buddyMessages.some(message => !message.opened);
+
+    return hasUnread
+      ? [{ type: 'OlderThan', buddyId, messageId: buddyMessages[0].id }]
+      : [];
+  };

--- a/src/features/Chat/selectors.ts
+++ b/src/features/Chat/selectors.ts
@@ -1,0 +1,129 @@
+import type { RootState } from '@/store';
+import type { AppMessage } from './chatPageApi';
+import type { ChatBuddy, PollingParam } from './mappers';
+
+import { createSelector } from 'reselect';
+
+const selectChatState = ({ chats }: RootState) => chats;
+
+const compareMessagesByTimeCreated = (
+  messageA: AppMessage,
+  messageB: AppMessage,
+): number =>
+  new Date(messageB.created).getTime() - new Date(messageA.created).getTime();
+
+const sortMessagesByDateDescending = (messages: AppMessage[]): AppMessage[] =>
+  [...messages].sort(compareMessagesByTimeCreated);
+
+const sortChats = (a: ChatBuddy, b: ChatBuddy): number => {
+  const aHasNoMessages = a.messages.length === 0;
+  const bHasNoMessages = b.messages.length === 0;
+
+  // If both chats have no messages, they are considered equal
+  if (aHasNoMessages && bHasNoMessages) return 0;
+
+  // If only a has no messages, it should come first
+  if (aHasNoMessages) return -1;
+
+  // If only b has no messages, it should come first
+  if (bHasNoMessages) return 1;
+
+  const mostRecentA = sortMessagesByDateDescending(a.messages)[0];
+  const mostRecentB = sortMessagesByDateDescending(b.messages)[0];
+  return compareMessagesByTimeCreated(mostRecentA, mostRecentB);
+};
+
+export const selectChats = createSelector(
+  selectChatState,
+  ({ activeFolder, chats }) =>
+    Object.values(chats)
+      .filter(chat => chat.status === activeFolder)
+      .sort(sortChats),
+);
+
+export const selectChatsExist = createSelector(
+  selectChatState,
+  ({ chats }) => Object.values(chats).length > 0,
+);
+
+export const selectActiveChat = createSelector(
+  selectChatState,
+  ({ activeChatId, chats }) => (activeChatId ? chats[activeChatId] : null),
+);
+
+export const selectActiveChatExists = createSelector(
+  selectChatState,
+  ({ activeChatId, chats }) => Boolean(activeChatId && chats[activeChatId]),
+);
+
+// Returns most recent unread chat, or the most recent if all are read
+export const selectDefaultChat = createSelector(selectChats, chats => {
+  const unreadChats = chats.filter(chat => {
+    if (chat.status !== 'ok') return false;
+    return chat.messages.some(message => !message.opened);
+  });
+
+  return unreadChats[0] ?? chats[0];
+});
+
+export const selectBuddyMessages = (buddyId: string) =>
+  createSelector(
+    selectChatState,
+    selectIsLoadingBuddyMessages(buddyId),
+    ({ chats }, isLoading) => {
+      const buddy = chats[buddyId];
+      const hasMessages = buddy.messages.length > 0;
+      const unread = buddy.messages.filter(message => !message.opened);
+
+      return {
+        latest: hasMessages
+          ? buddy.messages[buddy.messages.length - 1].content
+          : '',
+        unread: { hasUnread: unread.length > 0, count: unread.length },
+        isLoading,
+      };
+    },
+  );
+
+export const selectHasUnreadMessages = createSelector(
+  selectChatState,
+  ({ chats }): boolean =>
+    Object.values(chats)
+      .filter(chat => chat.status === 'ok')
+      .map(chat => chat.messages)
+      .flat()
+      .some(message => !message.opened),
+);
+
+const defaultParam: PollingParam = { type: 'New', previousMsgId: '' };
+export const selectCurrentPollingParams = createSelector(
+  selectChatState,
+  ({ pollingParams }) => {
+    if (!pollingParams) return null;
+    if (pollingParams.length === 0) return defaultParam;
+    return pollingParams[0];
+  },
+);
+
+const isLoadingOlderMessages = (pollingParams: PollingParam, buddyId: string) =>
+  pollingParams.type === 'OlderThan' && pollingParams.buddyId === buddyId;
+
+const isLoadingInitialMessages = (
+  pollingParams: PollingParam,
+  buddyId: string,
+) =>
+  pollingParams.type === 'InitialMessages' &&
+  pollingParams.buddyIds.includes(buddyId);
+
+export const selectIsLoadingBuddyMessages = (buddyId?: string) =>
+  createSelector(selectChatState, ({ pollingParams }) => {
+    if (!pollingParams || !buddyId) {
+      return false;
+    }
+
+    return pollingParams.some(
+      param =>
+        isLoadingOlderMessages(param, buddyId) ||
+        isLoadingInitialMessages(param, buddyId),
+    );
+  });

--- a/src/features/HomePage/index.tsx
+++ b/src/features/HomePage/index.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { selectHasUnreadMessages } from '@/features/Chat/chatSlice';
+import { selectHasUnreadMessages } from '@/features/Chat/selectors';
 import { useAppSelector } from '@/store';
 import { useGetLayoutMode } from '@/hooks/useGetLayoutMode';
 

--- a/src/features/Navigation/MobileDropdown/MobileNavItem.tsx
+++ b/src/features/Navigation/MobileDropdown/MobileNavItem.tsx
@@ -28,7 +28,12 @@ export const NavigationItem: React.FC<Props> = ({
       >
         {text}
       </LinkText>
-      {hasNotification && <NotificationCircle withBorder={isCurrentLocation} />}
+      {hasNotification && (
+        <UnseenDot
+          withBorder={isCurrentLocation}
+          aria-label="unseen-messages-dot"
+        />
+      )}
     </UnstyledRouteLink>
   );
 };
@@ -53,7 +58,7 @@ const LinkText = styled(Text)<{ isCurrentLocation: boolean }>`
     `}
 `;
 
-const NotificationCircle = styled.div<{ withBorder: boolean }>`
+const UnseenDot = styled.div<{ withBorder: boolean }>`
   background-color: ${palette.orange};
   ${({ withBorder }) => withBorder && `border: 1px solid ${palette.blueDark};`}
   border-radius: 50%;

--- a/src/features/Navigation/MobileDropdown/index.tsx
+++ b/src/features/Navigation/MobileDropdown/index.tsx
@@ -2,7 +2,7 @@ import { useComponentVisible } from '@/hooks/useComponentShow';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
-import { selectHasUnreadMessages } from '@/features/Chat/chatSlice';
+import { selectHasUnreadMessages } from '@/features/Chat/selectors';
 import { useAppSelector } from '@/store';
 
 import {

--- a/src/features/Navigation/NavigationItems.tsx
+++ b/src/features/Navigation/NavigationItems.tsx
@@ -25,7 +25,10 @@ export const Item = ({ hasNotification, text, url }: NavigationItem) => {
     >
       {text}
       {hasNotification && (
-        <NotificationCircle withBorder={isHovered || isCurrentLocation} />
+        <UnseenDot
+          withBorder={isHovered || isCurrentLocation}
+          aria-label="unseen-messages-dot"
+        />
       )}
     </Link>
   );
@@ -71,7 +74,7 @@ export const Link = styled(RouterNavLink)`
   }
 `;
 
-const NotificationCircle = styled.div<{ withBorder: boolean }>`
+const UnseenDot = styled.div<{ withBorder: boolean }>`
   background-color: ${palette.orange};
   ${({ withBorder }) => withBorder && `border: 1px solid ${palette.blueDark};`}
   border-radius: 50%;

--- a/src/features/Navigation/NavigationItems.tsx
+++ b/src/features/Navigation/NavigationItems.tsx
@@ -1,10 +1,11 @@
 import { NavLink as RouterNavLink, useLocation } from 'react-router-dom';
-import styled from 'styled-components';
 import { useState } from 'react';
 
-import { NAVIGATION_HEIGHT, palette } from '@/components/variables';
-import { selectHasUnreadMessages } from '../Chat/chatSlice';
+import { selectHasUnreadMessages } from '@/features/Chat/selectors';
 import { useAppSelector } from '@/store';
+
+import styled from 'styled-components';
+import { NAVIGATION_HEIGHT, palette } from '@/components/variables';
 
 export type NavigationItem = {
   hasNotification?: boolean;

--- a/src/hooks/useIsVisible.ts
+++ b/src/hooks/useIsVisible.ts
@@ -1,0 +1,48 @@
+import React from 'react';
+
+const VISIBILITY_THRESHOLD_TIME = 1000;
+
+export const useIsVisible = <T extends HTMLElement>(
+  ref: React.MutableRefObject<T | null>,
+) => {
+  const [isIntersecting, setIntersecting] = React.useState(false);
+  const timerRef = React.useRef<NodeJS.Timeout | null>(null);
+
+  React.useEffect(() => {
+    if (!ref.current) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          // Start a timer when the element becomes visible
+          timerRef.current = setTimeout(() => {
+            setIntersecting(true);
+          }, VISIBILITY_THRESHOLD_TIME);
+        } else {
+          // Clear the timer and reset visibility when the element is not visible
+          if (timerRef.current) {
+            clearTimeout(timerRef.current);
+            timerRef.current = null;
+          }
+          setIntersecting(false);
+        }
+      },
+      // The elemenet should be 100% visible
+      { threshold: 1.0 },
+    );
+
+    observer.observe(ref.current);
+
+    // Cleanup
+    return () => {
+      observer.disconnect();
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, [ref]);
+
+  return isIntersecting;
+};


### PR DESCRIPTION
# Description

Improves message-fetching logic, and logic for marking messages unseen and add some e2e tests to verify behaviour

- if initial-message fetch includes unread-messages, keep fetching until get a response with no unread, or all messages are fetched
- mark messages unseen only when they have been fully visible for 1 second
 
## Why was the change made?

Similar fixes to logic were made to mobile app few months ago, keep the feature parity

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Added new e2e-test suite for chats. 

- [] Unittest
- [x] Cypress e2e -tests

# Caveats?

NA

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
