### PR TITLE
Mentors can update their skills on the profile page

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -65,9 +65,7 @@ Cypress.Commands.add('getInputByLabel', (labelText: string) => {
   return cy
     .contains('label', labelText)
     .invoke('attr', 'for')
-    .then(inputId => {
-      return cy.get(`#${inputId}`);
-    });
+    .then(inputId => cy.get(`#${inputId}`));
 });
 
 Cypress.Commands.add('fillInputByLabel', (labelText: string, value: string) => {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -69,13 +69,23 @@ Cypress.Commands.add('getInputByLabel', (labelText: string) => {
 });
 
 Cypress.Commands.add('fillInputByLabel', (labelText: string, value: string) => {
-  cy.getInputByLabel(labelText).clear().type(value).blur();
+  cy.getInputByLabel(labelText)
+    .should('exist')
+    .should('be.visible')
+    .clear()
+    .type(value)
+    .blur();
 });
 
 Cypress.Commands.add(
   'fillNumberInputByLabel',
   (labelText: string, value: string) => {
-    cy.getInputByLabel(labelText).type('{selectall}').type(value).blur();
+    cy.getInputByLabel(labelText)
+      .should('exist')
+      .should('be.visible')
+      .type('{selectall}')
+      .type(value)
+      .blur();
   },
 );
 

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled, { css } from 'styled-components';
 import Text from '../Text';
 import { animations, palette } from '../constants';
-import CloseIcon from '@/static/icons/close.svg';
+import CloseIcon from '@/static/icons/close-with-background.svg';
 
 type Props = {
   text: string;

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -6,12 +6,17 @@ import CloseIcon from '@/static/icons/close-with-background.svg';
 
 type Props = {
   text: string;
-  isSelected: boolean;
-  shouldShake: boolean;
+  isSelected?: boolean;
+  shouldShake?: boolean;
   onToggle: (text: string) => void;
 };
 
-const Chip: React.FC<Props> = ({ text, isSelected, shouldShake, onToggle }) => {
+const Chip: React.FC<Props> = ({
+  text,
+  isSelected = true,
+  shouldShake = false,
+  onToggle,
+}) => {
   return (
     <StyledChip
       key={text}
@@ -33,13 +38,13 @@ const StyledChip = styled.button<{ isSelected: boolean; shouldShake: boolean }>`
   align-items: center;
   appearance: none;
   border: none;
-  border-radius: 1.75rem;
+  border-radius: 2rem;
   cursor: pointer;
   display: flex;
   flex: 0 0 auto;
   gap: 0.5rem;
   height: 2.75rem;
-  padding: 0.75rem 1.25rem;
+  padding: 0 1rem;
 
   ${({ isSelected }) =>
     isSelected

--- a/src/components/DropdownSearch/DropdownSearch.tsx
+++ b/src/components/DropdownSearch/DropdownSearch.tsx
@@ -6,12 +6,14 @@ import SearchBar from '../SearchBar';
 import Text from '../Text';
 
 type Props = {
+  isDisabled: boolean;
   options: string[];
   placeholder: string;
   selectOption: (option: string) => void;
 };
 
 export const DropdownSearch = ({
+  isDisabled,
   options,
   placeholder,
   selectOption,
@@ -20,6 +22,8 @@ export const DropdownSearch = ({
   const [notChosenOptions, setNotChosenOptions] = useState(options);
   const [filteredOptions, setFilteredOptions] = useState(options);
   const [isDropdownVisible, setIsDropdownVisible] = useState(false);
+
+  console.log('filtered options', filteredOptions);
 
   const handleQueryChange = (query: string) => {
     setQuery(query);
@@ -53,6 +57,7 @@ export const DropdownSearch = ({
   return (
     <Container>
       <SearchBar
+        isDisabled={isDisabled}
         hasOpenDropdown={isDropdownOpen}
         onBlur={handleBlur}
         onChange={handleQueryChange}

--- a/src/components/DropdownSearch/DropdownSearch.tsx
+++ b/src/components/DropdownSearch/DropdownSearch.tsx
@@ -17,6 +17,7 @@ export const DropdownSearch = ({
   selectOption,
 }: Props): JSX.Element => {
   const [query, setQuery] = useState('');
+  const [notChosenOptions, setNotChosenOptions] = useState(options);
   const [filteredOptions, setFilteredOptions] = useState(options);
   const [isDropdownVisible, setIsDropdownVisible] = useState(false);
 
@@ -25,7 +26,7 @@ export const DropdownSearch = ({
     setIsDropdownVisible(true);
     if (query.length > 0) {
       setFilteredOptions(
-        options.filter(option =>
+        notChosenOptions.filter(option =>
           option.toLowerCase().includes(query.toLowerCase()),
         ),
       );
@@ -36,7 +37,9 @@ export const DropdownSearch = ({
 
   const handleOptionClick = (option: string) => {
     setQuery('');
-    setFilteredOptions(options);
+    const notChosen = notChosenOptions.filter(o => o !== option);
+    setNotChosenOptions(notChosen);
+    setFilteredOptions(notChosen);
     setIsDropdownVisible(false);
     selectOption(option);
   };
@@ -45,10 +48,12 @@ export const DropdownSearch = ({
   const handleBlur = () => setTimeout(() => setIsDropdownVisible(false), 200);
   const handleFocus = () => setIsDropdownVisible(true);
 
+  const isDropdownOpen = isDropdownVisible && filteredOptions.length > 0;
+
   return (
     <Container>
       <SearchBar
-        hasOpenDropdown={isDropdownVisible}
+        hasOpenDropdown={isDropdownOpen}
         onBlur={handleBlur}
         onChange={handleQueryChange}
         onFocus={handleFocus}
@@ -56,7 +61,7 @@ export const DropdownSearch = ({
         value={query}
         variant="small"
       />
-      {isDropdownVisible && filteredOptions.length > 0 && (
+      {isDropdownOpen && (
         <Dropdown>
           {filteredOptions.map((option, index) => (
             <DropdownItem key={index} onClick={() => handleOptionClick(option)}>

--- a/src/components/DropdownSearch/DropdownSearch.tsx
+++ b/src/components/DropdownSearch/DropdownSearch.tsx
@@ -7,69 +7,50 @@ import Text from '../Text';
 
 type Props = {
   isDisabled: boolean;
+  isDropdownVisible: boolean;
   options: string[];
   placeholder: string;
   selectOption: (option: string) => void;
+  setIsDropdownVisible: (isVisible: boolean) => void;
 };
 
 export const DropdownSearch = ({
   isDisabled,
+  isDropdownVisible,
   options,
   placeholder,
   selectOption,
+  setIsDropdownVisible,
 }: Props): JSX.Element => {
   const [query, setQuery] = useState('');
-  const [notChosenOptions, setNotChosenOptions] = useState(options);
-  const [filteredOptions, setFilteredOptions] = useState(options);
-  const [isDropdownVisible, setIsDropdownVisible] = useState(false);
-
-  console.log('filtered options', filteredOptions);
-
-  const handleQueryChange = (query: string) => {
-    setQuery(query);
-    setIsDropdownVisible(true);
-    if (query.length > 0) {
-      setFilteredOptions(
-        notChosenOptions.filter(option =>
-          option.toLowerCase().includes(query.toLowerCase()),
-        ),
-      );
-    } else {
-      setFilteredOptions(options);
-    }
-  };
-
-  const handleOptionClick = (option: string) => {
-    setQuery('');
-    const notChosen = notChosenOptions.filter(o => o !== option);
-    setNotChosenOptions(notChosen);
-    setFilteredOptions(notChosen);
-    setIsDropdownVisible(false);
-    selectOption(option);
-  };
 
   // Delay dropdown hide to allow click event on options
   const handleBlur = () => setTimeout(() => setIsDropdownVisible(false), 200);
   const handleFocus = () => setIsDropdownVisible(true);
 
-  const isDropdownOpen = isDropdownVisible && filteredOptions.length > 0;
+  const filteredOptions = options.filter(
+    option =>
+      query.length === 0 || option.toLowerCase().includes(query.toLowerCase()),
+  );
+
+  const shouldShowDropdown = isDropdownVisible && filteredOptions.length > 0;
 
   return (
     <Container>
       <SearchBar
         isDisabled={isDisabled}
-        hasOpenDropdown={isDropdownOpen}
+        hasOpenDropdown={shouldShowDropdown}
         onBlur={handleBlur}
-        onChange={handleQueryChange}
+        onChange={setQuery}
         onFocus={handleFocus}
         placeholder={placeholder}
         value={query}
         variant="small"
       />
-      {isDropdownOpen && (
+      {shouldShowDropdown && (
         <Dropdown>
-          {filteredOptions.map((option, index) => (
-            <DropdownItem key={index} onClick={() => handleOptionClick(option)}>
+          {filteredOptions.map((option, i) => (
+            <DropdownItem key={i} onClick={() => selectOption(option)}>
               <Text variant="menuOption">{option}</Text>
             </DropdownItem>
           ))}

--- a/src/components/DropdownSearch/DropdownSearch.tsx
+++ b/src/components/DropdownSearch/DropdownSearch.tsx
@@ -1,66 +1,66 @@
 import styled from 'styled-components';
 import { useState } from 'react';
 
-import { DEFAULT_ICON_SIZE, palette } from '@/components/constants';
-import { iconVariants } from '@/components/Buttons/variants';
+import { palette } from '@/components/constants';
+import SearchBar from '../SearchBar';
 import Text from '../Text';
 
-export type InputType = 'number' | 'password' | 'text';
-
-type TextInputProps = {
-  addSkill: (value: string) => void;
+type Props = {
   options: string[];
-  placeholder?: string;
+  placeholder: string;
+  selectOption: (option: string) => void;
 };
 
 export const DropdownSearch = ({
-  addSkill,
   options,
-  placeholder = '',
-}: TextInputProps): JSX.Element => {
+  placeholder,
+  selectOption,
+}: Props): JSX.Element => {
   const [query, setQuery] = useState('');
   const [filteredOptions, setFilteredOptions] = useState(options);
-  const [isDropdownVisible, setDropdownVisible] = useState(false);
+  const [isDropdownVisible, setIsDropdownVisible] = useState(false);
 
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const inputValue = e.target.value;
-    setQuery(inputValue);
-    setFilteredOptions(
-      options.filter(option =>
-        option.toLowerCase().includes(inputValue.toLowerCase()),
-      ),
-    );
-    setDropdownVisible(true);
+  const handleQueryChange = (query: string) => {
+    setQuery(query);
+    setIsDropdownVisible(true);
+    if (query.length > 0) {
+      setFilteredOptions(
+        options.filter(option =>
+          option.toLowerCase().includes(query.toLowerCase()),
+        ),
+      );
+    } else {
+      setFilteredOptions(options);
+    }
   };
 
-  const handleSkillClick = (option: string) => {
+  const handleOptionClick = (option: string) => {
     setQuery('');
     setFilteredOptions(options);
-    addSkill(option);
-    setDropdownVisible(false);
+    setIsDropdownVisible(false);
+    selectOption(option);
   };
 
-  const handleBlur = () => {
-    // Delay dropdown hide to allow click event on options
-    setTimeout(() => setDropdownVisible(false), 200);
-  };
+  // Delay dropdown hide to allow click event on options
+  const handleBlur = () => setTimeout(() => setIsDropdownVisible(false), 200);
+  const handleFocus = () => setIsDropdownVisible(true);
 
   return (
     <Container>
-      <LeftIcon />
-      <SearchInput
-        type="text"
-        value={query}
-        onChange={handleInputChange}
+      <SearchBar
+        hasOpenDropdown={isDropdownVisible}
         onBlur={handleBlur}
-        onFocus={() => setDropdownVisible(true)}
+        onChange={handleQueryChange}
+        onFocus={handleFocus}
         placeholder={placeholder}
+        value={query}
+        variant="small"
       />
       {isDropdownVisible && filteredOptions.length > 0 && (
         <Dropdown>
           {filteredOptions.map((option, index) => (
-            <DropdownItem key={index} onClick={() => handleSkillClick(option)}>
-              <Text>{option}</Text>
+            <DropdownItem key={index} onClick={() => handleOptionClick(option)}>
+              <Text variant="menuOption">{option}</Text>
             </DropdownItem>
           ))}
         </Dropdown>
@@ -70,57 +70,32 @@ export const DropdownSearch = ({
 };
 
 const Container = styled.div`
-  display: inline-block;
+  margin: 1rem 0;
+  max-width: 350px;
   position: relative;
-  width: 100%;
-`;
-
-const SearchInput = styled.input`
-  border: 1px solid ${palette.purple};
-  border-radius: 20px;
-  font-family: Source Sans Pro;
-  font-size: 1rem;
-  font-style: normal;
-  font-weight: 400;
-  line-height: 1.5rem;
-  padding: 0.5rem 60px;
-  width: 100%;
 `;
 
 const Dropdown = styled.div`
   background-color: white;
   border: 1px solid ${palette.purple};
-  border-radius: 10px;
+  border-radius: 0 0 20px 20px;
   box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.1);
-  left: 0;
+  box-sizing: border-box;
   max-height: 200px;
+  outline: ${palette.purple} solid 2px;
   overflow-y: auto;
   position: absolute;
-  top: calc(100% + 5px);
   width: 100%;
   z-index: 10;
 `;
 
 const DropdownItem = styled.div`
-  background-color: white;
   cursor: pointer;
-  padding: 10px;
+  padding: 0.5rem 1rem;
 
   &:hover {
-    background-color: ${palette.purpleHover};
+    background-color: ${palette.blueLight};
   }
-`;
-
-const LeftIcon = styled.div`
-  background-image: ${iconVariants['search']};
-  background-repeat: no-repeat;
-  background-size: contain;
-  height: ${DEFAULT_ICON_SIZE.SMALL}px;
-  left: 10px;
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  width: ${DEFAULT_ICON_SIZE.SMALL}px;
 `;
 
 export default DropdownSearch;

--- a/src/components/DropdownSearch/DropdownSearch.tsx
+++ b/src/components/DropdownSearch/DropdownSearch.tsx
@@ -48,7 +48,7 @@ export const DropdownSearch = ({
         variant="small"
       />
       {shouldShowDropdown && (
-        <Dropdown>
+        <Dropdown id="skill-dropdown">
           {filteredOptions.map((option, i) => (
             <DropdownItem key={i} onClick={() => selectOption(option)}>
               <Text variant="menuOption">{option}</Text>

--- a/src/components/DropdownSearch/DropdownSearch.tsx
+++ b/src/components/DropdownSearch/DropdownSearch.tsx
@@ -1,32 +1,79 @@
 import styled from 'styled-components';
+import { useState } from 'react';
 
 import { DEFAULT_ICON_SIZE, palette } from '@/components/constants';
 import { iconVariants } from '@/components/Buttons/variants';
+import Text from '../Text';
 
 export type InputType = 'number' | 'password' | 'text';
 
 type TextInputProps = {
-  onChange: (value: string) => void;
+  addSkill: (value: string) => void;
   options: string[];
   placeholder?: string;
-  value: string;
 };
 
 export const DropdownSearch = ({
-  onChange,
-  // options,
+  addSkill,
+  options,
   placeholder = '',
-  value,
-}: TextInputProps): JSX.Element => (
-  <>
-    <LeftIcon />
-    <SearchInput
-      onChange={e => onChange(e.target.value)}
-      placeholder={placeholder}
-      value={value}
-    />
-  </>
-);
+}: TextInputProps): JSX.Element => {
+  const [query, setQuery] = useState('');
+  const [filteredOptions, setFilteredOptions] = useState(options);
+  const [isDropdownVisible, setDropdownVisible] = useState(false);
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const inputValue = e.target.value;
+    setQuery(inputValue);
+    setFilteredOptions(
+      options.filter(option =>
+        option.toLowerCase().includes(inputValue.toLowerCase()),
+      ),
+    );
+    setDropdownVisible(true);
+  };
+
+  const handleSkillClick = (option: string) => {
+    setQuery('');
+    setFilteredOptions(options);
+    addSkill(option);
+    setDropdownVisible(false);
+  };
+
+  const handleBlur = () => {
+    // Delay dropdown hide to allow click event on options
+    setTimeout(() => setDropdownVisible(false), 200);
+  };
+
+  return (
+    <Container>
+      <LeftIcon />
+      <SearchInput
+        type="text"
+        value={query}
+        onChange={handleInputChange}
+        onBlur={handleBlur}
+        onFocus={() => setDropdownVisible(true)}
+        placeholder={placeholder}
+      />
+      {isDropdownVisible && filteredOptions.length > 0 && (
+        <Dropdown>
+          {filteredOptions.map((option, index) => (
+            <DropdownItem key={index} onClick={() => handleSkillClick(option)}>
+              <Text>{option}</Text>
+            </DropdownItem>
+          ))}
+        </Dropdown>
+      )}
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  display: inline-block;
+  position: relative;
+  width: 100%;
+`;
 
 const SearchInput = styled.input`
   border: 1px solid ${palette.purple};
@@ -37,6 +84,31 @@ const SearchInput = styled.input`
   font-weight: 400;
   line-height: 1.5rem;
   padding: 0.5rem 60px;
+  width: 100%;
+`;
+
+const Dropdown = styled.div`
+  background-color: white;
+  border: 1px solid ${palette.purple};
+  border-radius: 10px;
+  box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.1);
+  left: 0;
+  max-height: 200px;
+  overflow-y: auto;
+  position: absolute;
+  top: calc(100% + 5px);
+  width: 100%;
+  z-index: 10;
+`;
+
+const DropdownItem = styled.div`
+  background-color: white;
+  cursor: pointer;
+  padding: 10px;
+
+  &:hover {
+    background-color: ${palette.purpleHover};
+  }
 `;
 
 const LeftIcon = styled.div`
@@ -44,8 +116,10 @@ const LeftIcon = styled.div`
   background-repeat: no-repeat;
   background-size: contain;
   height: ${DEFAULT_ICON_SIZE.SMALL}px;
-  position: relative;
-  transform: translate(${DEFAULT_ICON_SIZE.SMALL + 22}px);
+  left: 10px;
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
   width: ${DEFAULT_ICON_SIZE.SMALL}px;
 `;
 

--- a/src/components/DropdownSearch/DropdownSearch.tsx
+++ b/src/components/DropdownSearch/DropdownSearch.tsx
@@ -1,0 +1,52 @@
+import styled from 'styled-components';
+
+import { DEFAULT_ICON_SIZE, palette } from '@/components/constants';
+import { iconVariants } from '@/components/Buttons/variants';
+
+export type InputType = 'number' | 'password' | 'text';
+
+type TextInputProps = {
+  onChange: (value: string) => void;
+  options: string[];
+  placeholder?: string;
+  value: string;
+};
+
+export const DropdownSearch = ({
+  onChange,
+  // options,
+  placeholder = '',
+  value,
+}: TextInputProps): JSX.Element => (
+  <>
+    <LeftIcon />
+    <SearchInput
+      onChange={e => onChange(e.target.value)}
+      placeholder={placeholder}
+      value={value}
+    />
+  </>
+);
+
+const SearchInput = styled.input`
+  border: 1px solid ${palette.purple};
+  border-radius: 20px;
+  font-family: Source Sans Pro;
+  font-size: 1rem;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 1.5rem;
+  padding: 0.5rem 60px;
+`;
+
+const LeftIcon = styled.div`
+  background-image: ${iconVariants['search']};
+  background-repeat: no-repeat;
+  background-size: contain;
+  height: ${DEFAULT_ICON_SIZE.SMALL}px;
+  position: relative;
+  transform: translate(${DEFAULT_ICON_SIZE.SMALL + 22}px);
+  width: ${DEFAULT_ICON_SIZE.SMALL}px;
+`;
+
+export default DropdownSearch;

--- a/src/components/DropdownSearch/index.ts
+++ b/src/components/DropdownSearch/index.ts
@@ -1,0 +1,3 @@
+import DropdownSearch from './DropdownSearch';
+
+export { DropdownSearch };

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -1,6 +1,6 @@
 import styled, { css, FlattenSimpleInterpolation } from 'styled-components';
-import SearchIconImg from '@/static/icons/search.svg';
 import { palette } from '../constants';
+import SearchIconImg from '@/static/icons/search.svg';
 
 type Variant = 'small' | 'normal';
 

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -7,7 +7,7 @@ type Variant = 'small' | 'normal';
 type SearchProps = {
   className?: string;
   hasOpenDropdown?: boolean;
-  isDisabled: boolean;
+  isDisabled?: boolean;
   onBlur?: () => void;
   onChange: (value: string) => void;
   onFocus?: () => void;
@@ -28,7 +28,7 @@ const sizingMap: Record<Variant, FlattenSimpleInterpolation> = {
 const SearchBar: React.FC<SearchProps> = ({
   className,
   hasOpenDropdown = false,
-  isDisabled,
+  isDisabled = false,
   onBlur,
   onChange,
   onFocus,

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -7,6 +7,7 @@ type Variant = 'small' | 'normal';
 type SearchProps = {
   className?: string;
   hasOpenDropdown?: boolean;
+  isDisabled: boolean;
   onBlur?: () => void;
   onChange: (value: string) => void;
   onFocus?: () => void;
@@ -27,6 +28,7 @@ const sizingMap: Record<Variant, FlattenSimpleInterpolation> = {
 const SearchBar: React.FC<SearchProps> = ({
   className,
   hasOpenDropdown = false,
+  isDisabled,
   onBlur,
   onChange,
   onFocus,
@@ -36,6 +38,7 @@ const SearchBar: React.FC<SearchProps> = ({
   <SearchBox className={className}>
     <SearchIcon />
     <SearchInput
+      disabled={isDisabled}
       hasOpenDropdown={hasOpenDropdown}
       onBlur={onBlur}
       onChange={e => onChange(e.target.value)}

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -5,11 +5,14 @@ import { palette } from '../constants';
 type Variant = 'small' | 'normal';
 
 type SearchProps = {
+  className?: string;
+  hasOpenDropdown?: boolean;
+  onBlur?: () => void;
+  onChange: (value: string) => void;
+  onFocus?: () => void;
   placeholder: string;
   value: string;
-  onChange: (value: string) => void;
   variant: Variant;
-  className?: string;
 };
 
 const sizingMap: Record<Variant, FlattenSimpleInterpolation> = {
@@ -22,25 +25,35 @@ const sizingMap: Record<Variant, FlattenSimpleInterpolation> = {
 };
 
 const SearchBar: React.FC<SearchProps> = ({
-  onChange,
-  variant,
   className,
+  hasOpenDropdown = false,
+  onBlur,
+  onChange,
+  onFocus,
+  variant,
   ...props
 }) => (
   <SearchBox className={className}>
     <SearchIcon />
     <SearchInput
+      hasOpenDropdown={hasOpenDropdown}
+      onBlur={onBlur}
+      onChange={e => onChange(e.target.value)}
+      onFocus={onFocus}
       type="text"
       variant={variant}
       {...props}
-      onChange={e => onChange(e.target.value)}
     ></SearchInput>
   </SearchBox>
 );
 
-const SearchInput = styled.input<{ variant: Variant }>`
-  border: ${palette.purple} solid 1px;
-  border-radius: 1.75rem;
+const SearchInput = styled.input<{
+  hasOpenDropdown: boolean;
+  variant: Variant;
+}>`
+  border: 1px solid ${palette.purple};
+  border-radius: ${({ hasOpenDropdown }) =>
+    hasOpenDropdown ? '20px 20px 0 0' : '20px'};
   box-sizing: border-box;
   display: flex;
   flex: 1;

--- a/src/components/Text/variants.ts
+++ b/src/components/Text/variants.ts
@@ -141,6 +141,17 @@ export const variants = {
       textTransform: 'uppercase',
     },
   },
+  menuOption: {
+    element: 'p',
+    styles: {
+      fontFamily: '"Source Sans Pro"',
+      fontSize: '1rem',
+      fontStyle: 'normal',
+      fontWeight: 400,
+      lineHeight: '1.5rem',
+      margin: 0,
+    },
+  },
   p: {
     element: 'p',
     styles: {

--- a/src/features/Chat/selectors.ts
+++ b/src/features/Chat/selectors.ts
@@ -110,8 +110,7 @@ export const selectHasUnreadMessages = createSelector(
   ({ chats }): boolean =>
     Object.values(chats)
       .filter(chat => chat.status === 'ok')
-      .map(chat => chat.messages)
-      .flat()
+      .flatMap(chat => chat.messages)
       .some(message => !message.opened),
 );
 

--- a/src/features/HomePage/index.tsx
+++ b/src/features/HomePage/index.tsx
@@ -39,15 +39,15 @@ const HomePage = () => {
         <Info />
       </TopContainer>
       <MiddleContainer>
-        <LeftMiddleContainer>
+        <InnerContainer>
           {hasUnreadMessages ? <NewMessages /> : <Welcome />}
           {!mentor && <Announcements />}
           {mentor && <ProfileWidget mentor={mentor} />}
-        </LeftMiddleContainer>
-        <RightMiddleContainer>
+        </InnerContainer>
+        <InnerContainer>
           {mentor && <Announcements />}
           <Concepts />
-        </RightMiddleContainer>
+        </InnerContainer>
       </MiddleContainer>
       <NewestMentors />
     </PageWithTransition>
@@ -69,14 +69,7 @@ const MiddleContainer = styled.div`
   padding: 4rem ${OUTER_HORIZONTAL_MARGIN};
 `;
 
-const LeftMiddleContainer = styled.div`
-  display: flex;
-  flex: 1;
-  flex-direction: column;
-  gap: 2rem;
-`;
-
-const RightMiddleContainer = styled.div`
+const InnerContainer = styled.div`
   display: flex;
   flex: 1;
   flex-direction: column;

--- a/src/features/MentorPage/mentorPageApi.ts
+++ b/src/features/MentorPage/mentorPageApi.ts
@@ -1,7 +1,6 @@
 import { createApi } from '@reduxjs/toolkit/query/react';
 import * as D from 'io-ts/Decoder';
 import { parseAndTransformTo, refreshingBaseQuery } from '@/utils/http';
-import { capitalize } from '@/utils/utils';
 import toast from 'react-hot-toast';
 import { t } from 'i18next';
 
@@ -57,7 +56,7 @@ const toMentor = ({
   mentorId: id,
   name: display_name,
   region,
-  skills: skills.map(skill => capitalize(skill)),
+  skills,
   statusMessage: status_message,
   story,
 });

--- a/src/features/MentorPage/selectors.ts
+++ b/src/features/MentorPage/selectors.ts
@@ -39,6 +39,14 @@ export const selectMentorById = (buddyId: string | null) =>
     buddyId ? mentors.data?.[buddyId] : undefined,
   );
 
+export const selectAllSkillOptions = () =>
+  createSelector(selectMentors, mentorsQuery => {
+    const mentors = mentorsQuery.data ?? {};
+    const skills = Object.values(mentors).flatMap(mentor => mentor.skills);
+    const uniqueSkills = Array.from(new Set(skills));
+    return uniqueSkills;
+  });
+
 export const selectSkills = () =>
   createSelector(
     selectMentors,

--- a/src/features/ProfilePage/components/PublicInfo.tsx
+++ b/src/features/ProfilePage/components/PublicInfo.tsx
@@ -149,7 +149,10 @@ const PublicInfo = () => {
           rows={4}
           value={localData.story}
         />
-        <SkillsEditor skills={localData.skills} />
+        <SkillsEditor
+          onChange={value => updateMentorData('skills', value)}
+          skills={localData.skills}
+        />
       </Form>
     </Container>
   );

--- a/src/features/ProfilePage/components/PublicInfo.tsx
+++ b/src/features/ProfilePage/components/PublicInfo.tsx
@@ -8,8 +8,9 @@ import { useUpdateMentorMutation } from '@/features/MentorPage/mentorPageApi';
 import { useUpdateUserMutation } from '@/features/Authentication/authenticationApi';
 
 import { ButtonRow } from '.';
-import { DEFAULT_ICON_SIZE, palette } from '@/components/constants';
 import LabeledInput from '@/components/LabeledInput';
+import { palette } from '@/components/constants';
+import SkillsEditor from './SkillsEditor';
 import Slider from '@/components/Slider';
 import Text from '@/components/Text';
 import { TextButton } from '@/components/Buttons';
@@ -28,7 +29,6 @@ const PublicInfo = () => {
 
   const [localData, setLocalData] = useState<ApiMentor>(mentor);
   const [isDirty, setIsDirty] = useState(false);
-  const [skillSearchValue, setSkillSearchValue] = useState('');
 
   const updateMentorData = <K extends keyof ApiMentor>(
     key: K,
@@ -149,20 +149,7 @@ const PublicInfo = () => {
           rows={4}
           value={localData.story}
         />
-        <Label variant="label">{t('public.mentor.skills')}</Label>
-        <SearchBar>
-          <SkillSearch
-            variant="iconInput"
-            color={skillSearchValue ? 'blueDark' : 'greyFaded'}
-            leftIcon={{
-              sizeInPx: DEFAULT_ICON_SIZE.SMALL,
-              variant: 'search',
-            }}
-            onChange={setSkillSearchValue}
-            placeholder={t('public.mentor.addSkill')}
-            value={skillSearchValue}
-          />
-        </SearchBar>
+        <SkillsEditor skills={localData.skills} />
       </Form>
     </Container>
   );
@@ -206,28 +193,6 @@ const Column = styled.div`
 
 const StoryInput = styled(TextInput)`
   margin-top: 0.5rem;
-`;
-
-const Label = styled(Text)`
-  margin-top: 1rem;
-`;
-
-const SearchBar = styled.div`
-  align-items: center;
-  align-self: flex-start;
-  display: flex;
-  flex: 1;
-  justify-content: flex-end;
-  margin-left: -${DEFAULT_ICON_SIZE.SMALL}px;
-  margin-top: 1rem;
-`;
-
-const SkillSearch = styled(TextInput)`
-  max-width: 350px;
-
-  &:focus {
-    outline: 1px solid ${palette.purple};
-  }
 `;
 
 export default PublicInfo;

--- a/src/features/ProfilePage/components/PublicInfo.tsx
+++ b/src/features/ProfilePage/components/PublicInfo.tsx
@@ -150,7 +150,7 @@ const PublicInfo = () => {
           value={localData.story}
         />
         <SkillsEditor
-          onChange={value => updateMentorData('skills', value)}
+          updateSkills={skills => updateMentorData('skills', skills)}
           skills={localData.skills}
         />
       </Form>

--- a/src/features/ProfilePage/components/SkillsEditor.tsx
+++ b/src/features/ProfilePage/components/SkillsEditor.tsx
@@ -5,76 +5,51 @@ import { selectAllSkillOptions } from '@/features/MentorPage/selectors';
 import { useAppSelector } from '@/store';
 
 import { Chip } from '@/components/Chip';
-import { DEFAULT_ICON_SIZE } from '@/components/constants';
 import DropdownSearch from '@/components/DropdownSearch/DropdownSearch';
 import Text from '@/components/Text';
 
 type Props = {
-  onChange: (value: string[]) => void;
+  updateSkills: (skills: string[]) => void;
   skills: string[];
 };
 
-const SkillsEditor = ({ onChange, skills }: Props) => {
+const SkillsEditor = ({ updateSkills, skills }: Props) => {
   const { t } = useTranslation('profile');
+  const skillOptions = useAppSelector(selectAllSkillOptions());
 
-  const skillSelection = useAppSelector(selectAllSkillOptions());
+  const addSkill = (skill: string) => updateSkills([...skills, skill]);
 
-  const addSkill = (skill: string) => {
-    onChange([...skills, skill]);
-  };
-
-  const removeSkill = (skill: string) => {
-    const updatedSkills = skills.filter(s => s !== skill);
-    onChange(updatedSkills);
-  };
+  const removeSkill = (skill: string) =>
+    updateSkills(skills.filter(s => s !== skill));
 
   return (
-    <>
-      <Label variant="label">{t('public.mentor.skills')}</Label>
+    <Container>
+      <Text variant="label">{t('public.mentor.skills')}</Text>
       <Skills>
         {skills.map(skill => (
-          <Chip
-            key={skill}
-            text={skill}
-            isSelected={true}
-            shouldShake={false}
-            onToggle={removeSkill}
-          />
+          <Chip key={skill} text={skill} onToggle={removeSkill} />
         ))}
       </Skills>
-      <SearchBar>
-        <DropdownSearch
-          addSkill={addSkill}
-          options={skillSelection}
-          placeholder={t('public.mentor.addSkill')}
-        />
-      </SearchBar>
-    </>
+      <DropdownSearch
+        options={skillOptions.filter(so => !skills.includes(so))} // Options should not include already chosen skills
+        placeholder={t('public.mentor.addSkill')}
+        selectOption={addSkill}
+      />
+    </Container>
   );
 };
 
-const Label = styled(Text)`
-  margin-top: 1rem;
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin: 1rem 0;
 `;
 
 const Skills = styled.div`
   display: flex;
-  flex: 0 0 auto;
   flex-wrap: wrap;
   gap: 1rem;
-  overflow: hidden;
-  width: 100%;
-`;
-
-const SearchBar = styled.div`
-  align-items: center;
-  align-self: flex-start;
-  display: flex;
-  flex: 1;
-  justify-content: flex-end;
-  margin-left: -${DEFAULT_ICON_SIZE.SMALL}px;
-  margin-top: 1rem;
-  max-width: 350px;
+  margin-top: 0.5rem;
 `;
 
 export default SkillsEditor;

--- a/src/features/ProfilePage/components/SkillsEditor.tsx
+++ b/src/features/ProfilePage/components/SkillsEditor.tsx
@@ -1,0 +1,61 @@
+import styled from 'styled-components';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { DEFAULT_ICON_SIZE, palette } from '@/components/constants';
+import Text from '@/components/Text';
+import TextInput from '@/components/TextInput';
+
+type Props = {
+  skills: string[];
+};
+
+const SkillsEditor = ({ skills }: Props) => {
+  const { t } = useTranslation('profile');
+  const [skillSearchValue, setSkillSearchValue] = useState('');
+
+  console.log(skills);
+
+  return (
+    <>
+      <Label variant="label">{t('public.mentor.skills')}</Label>
+      <SearchBar>
+        <SkillSearch
+          variant="iconInput"
+          color={skillSearchValue ? 'blueDark' : 'greyFaded'}
+          leftIcon={{
+            sizeInPx: DEFAULT_ICON_SIZE.SMALL,
+            variant: 'search',
+          }}
+          onChange={setSkillSearchValue}
+          placeholder={t('public.mentor.addSkill')}
+          value={skillSearchValue}
+        />
+      </SearchBar>
+    </>
+  );
+};
+
+const Label = styled(Text)`
+  margin-top: 1rem;
+`;
+
+const SearchBar = styled.div`
+  align-items: center;
+  align-self: flex-start;
+  display: flex;
+  flex: 1;
+  justify-content: flex-end;
+  margin-left: -${DEFAULT_ICON_SIZE.SMALL}px;
+  margin-top: 1rem;
+`;
+
+const SkillSearch = styled(TextInput)`
+  max-width: 350px;
+
+  &:focus {
+    outline: 1px solid ${palette.purple};
+  }
+`;
+
+export default SkillsEditor;

--- a/src/features/ProfilePage/components/SkillsEditor.tsx
+++ b/src/features/ProfilePage/components/SkillsEditor.tsx
@@ -2,9 +2,13 @@ import styled from 'styled-components';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { DEFAULT_ICON_SIZE, palette } from '@/components/constants';
+import { selectSkills } from '@/features/MentorPage/selectors';
+import { useAppSelector } from '@/store';
+
+import { Chip } from '@/components/Chip';
+import { DEFAULT_ICON_SIZE } from '@/components/constants';
+import DropdownSearch from '@/components/DropdownSearch/DropdownSearch';
 import Text from '@/components/Text';
-import TextInput from '@/components/TextInput';
 
 type Props = {
   skills: string[];
@@ -12,22 +16,29 @@ type Props = {
 
 const SkillsEditor = ({ skills }: Props) => {
   const { t } = useTranslation('profile');
-  const [skillSearchValue, setSkillSearchValue] = useState('');
 
-  console.log(skills);
+  const skillSelection = useAppSelector(selectSkills());
+
+  const [skillSearchValue, setSkillSearchValue] = useState('');
 
   return (
     <>
       <Label variant="label">{t('public.mentor.skills')}</Label>
+      <Skills>
+        {skills.map(skill => (
+          <Chip
+            key={skill}
+            text={skill}
+            isSelected={true}
+            shouldShake={false}
+            onToggle={() => null}
+          />
+        ))}
+      </Skills>
       <SearchBar>
-        <SkillSearch
-          variant="iconInput"
-          color={skillSearchValue ? 'blueDark' : 'greyFaded'}
-          leftIcon={{
-            sizeInPx: DEFAULT_ICON_SIZE.SMALL,
-            variant: 'search',
-          }}
+        <DropdownSearch
           onChange={setSkillSearchValue}
+          options={skillSelection}
           placeholder={t('public.mentor.addSkill')}
           value={skillSearchValue}
         />
@@ -40,6 +51,15 @@ const Label = styled(Text)`
   margin-top: 1rem;
 `;
 
+const Skills = styled.div`
+  display: flex;
+  flex: 0 0 auto;
+  flex-wrap: wrap;
+  gap: 1rem;
+  overflow: hidden;
+  width: 100%;
+`;
+
 const SearchBar = styled.div`
   align-items: center;
   align-self: flex-start;
@@ -48,14 +68,7 @@ const SearchBar = styled.div`
   justify-content: flex-end;
   margin-left: -${DEFAULT_ICON_SIZE.SMALL}px;
   margin-top: 1rem;
-`;
-
-const SkillSearch = styled(TextInput)`
   max-width: 350px;
-
-  &:focus {
-    outline: 1px solid ${palette.purple};
-  }
 `;
 
 export default SkillsEditor;

--- a/src/features/ProfilePage/components/SkillsEditor.tsx
+++ b/src/features/ProfilePage/components/SkillsEditor.tsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { selectAllSkillOptions } from '@/features/MentorPage/selectors';
@@ -6,7 +7,9 @@ import { useAppSelector } from '@/store';
 import { useGetMentorsQuery } from '@/features/MentorPage/mentorPageApi';
 
 import { Chip } from '@/components/Chip';
-import DropdownSearch from '@/components/DropdownSearch/DropdownSearch';
+import { Column } from '@/components/common';
+import { palette } from '@/components/constants';
+import SearchBar from '@/components/SearchBar';
 import Text from '@/components/Text';
 
 type Props = {
@@ -18,16 +21,52 @@ const SkillsEditor = ({ updateSkills, skills }: Props) => {
   const { t } = useTranslation('profile');
 
   // This should be run before all skill options are selected
-  useGetMentorsQuery();
+  console.log('Haetaan mentorit');
+  const { isLoading } = useGetMentorsQuery();
+  console.log('Ladataan on', isLoading);
 
   const allSkills = useAppSelector(selectAllSkillOptions());
   // Options should not include already chosen skills
-  const skillOptions = allSkills.filter(s => !skills.includes(s));
 
   const addSkill = (skill: string) => updateSkills([...skills, skill]);
 
-  const removeSkill = (skill: string) =>
+  const removeSkill = (skill: string) => {
     updateSkills(skills.filter(s => s !== skill));
+    // setNotChosenOptions([...notChosenOptions, skill]);
+    // setFilteredOptions([...filteredOptions, skill]);
+  };
+
+  // Pasted code
+  const [query, setQuery] = useState('');
+  const [isDropdownVisible, setIsDropdownVisible] = useState(false);
+
+  // const [notChosenOptions, setNotChosenOptions] = useState(skillOptions);
+  // const [filteredOptions, setFilteredOptions] = useState(skillOptions);
+
+  const handleOptionClick = (option: string) => {
+    setQuery('');
+    // const notChosen = notChosenOptions.filter(o => o !== option);
+    // setNotChosenOptions(notChosen);
+    // setFilteredOptions(notChosen);
+    setIsDropdownVisible(false);
+    addSkill(option);
+  };
+
+  // Delay dropdown hide to allow click event on options
+  const handleBlur = () => setTimeout(() => setIsDropdownVisible(false), 200);
+  const handleFocus = () => setIsDropdownVisible(true);
+
+  const getSkillsToShowInDropdown = (): string[] => {
+    return allSkills
+      .filter(option => !skills.includes(option))
+      .filter(option => {
+        if (query.length === 0) return option;
+        return option.toLowerCase().includes(query.toLowerCase());
+      });
+  };
+
+  const isDropdownOpen =
+    isDropdownVisible && getSkillsToShowInDropdown().length > 0;
 
   return (
     <Container>
@@ -37,18 +76,35 @@ const SkillsEditor = ({ updateSkills, skills }: Props) => {
           <Chip key={skill} text={skill} onToggle={removeSkill} />
         ))}
       </Skills>
-      <DropdownSearch
-        options={skillOptions}
-        placeholder={t('public.mentor.addSkill')}
-        selectOption={addSkill}
-      />
+      <InnerContainer>
+        <SearchBar
+          isDisabled={isLoading}
+          hasOpenDropdown={isDropdownOpen}
+          onBlur={handleBlur}
+          onChange={setQuery}
+          onFocus={handleFocus}
+          placeholder={t('public.mentor.addSkill')}
+          value={query}
+          variant="small"
+        />
+        {isDropdownOpen && (
+          <Dropdown>
+            {getSkillsToShowInDropdown().map((option, index) => (
+              <DropdownItem
+                key={index}
+                onClick={() => handleOptionClick(option)}
+              >
+                <Text variant="menuOption">{option}</Text>
+              </DropdownItem>
+            ))}
+          </Dropdown>
+        )}
+      </InnerContainer>
     </Container>
   );
 };
 
-const Container = styled.div`
-  display: flex;
-  flex-direction: column;
+const Container = styled(Column)`
   margin: 1rem 0;
 `;
 
@@ -57,6 +113,35 @@ const Skills = styled.div`
   flex-wrap: wrap;
   gap: 1rem;
   margin-top: 0.5rem;
+`;
+
+const InnerContainer = styled.div`
+  margin: 1rem 0;
+  max-width: 350px;
+  position: relative;
+`;
+
+const Dropdown = styled.div`
+  background-color: white;
+  border: 1px solid ${palette.purple};
+  border-radius: 0 0 20px 20px;
+  box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.1);
+  box-sizing: border-box;
+  max-height: 200px;
+  outline: ${palette.purple} solid 2px;
+  overflow-y: auto;
+  position: absolute;
+  width: 100%;
+  z-index: 10;
+`;
+
+const DropdownItem = styled.div`
+  cursor: pointer;
+  padding: 0.5rem 1rem;
+
+  &:hover {
+    background-color: ${palette.blueLight};
+  }
 `;
 
 export default SkillsEditor;

--- a/src/features/ProfilePage/components/SkillsEditor.tsx
+++ b/src/features/ProfilePage/components/SkillsEditor.tsx
@@ -8,8 +8,7 @@ import { useGetMentorsQuery } from '@/features/MentorPage/mentorPageApi';
 
 import { Chip } from '@/components/Chip';
 import { Column } from '@/components/common';
-import { palette } from '@/components/constants';
-import SearchBar from '@/components/SearchBar';
+import DropdownSearch from '@/components/DropdownSearch/DropdownSearch';
 import Text from '@/components/Text';
 
 type Props = {
@@ -20,53 +19,23 @@ type Props = {
 const SkillsEditor = ({ updateSkills, skills }: Props) => {
   const { t } = useTranslation('profile');
 
-  // This should be run before all skill options are selected
-  console.log('Haetaan mentorit');
   const { isLoading } = useGetMentorsQuery();
-  console.log('Ladataan on', isLoading);
-
   const allSkills = useAppSelector(selectAllSkillOptions());
-  // Options should not include already chosen skills
 
-  const addSkill = (skill: string) => updateSkills([...skills, skill]);
-
-  const removeSkill = (skill: string) => {
-    updateSkills(skills.filter(s => s !== skill));
-    // setNotChosenOptions([...notChosenOptions, skill]);
-    // setFilteredOptions([...filteredOptions, skill]);
-  };
-
-  // Pasted code
-  const [query, setQuery] = useState('');
   const [isDropdownVisible, setIsDropdownVisible] = useState(false);
 
-  // const [notChosenOptions, setNotChosenOptions] = useState(skillOptions);
-  // const [filteredOptions, setFilteredOptions] = useState(skillOptions);
-
-  const handleOptionClick = (option: string) => {
-    setQuery('');
-    // const notChosen = notChosenOptions.filter(o => o !== option);
-    // setNotChosenOptions(notChosen);
-    // setFilteredOptions(notChosen);
+  const addSkill = (skill: string) => {
     setIsDropdownVisible(false);
-    addSkill(option);
+    updateSkills([...skills, skill]);
   };
 
-  // Delay dropdown hide to allow click event on options
-  const handleBlur = () => setTimeout(() => setIsDropdownVisible(false), 200);
-  const handleFocus = () => setIsDropdownVisible(true);
-
-  const getSkillsToShowInDropdown = (): string[] => {
-    return allSkills
-      .filter(option => !skills.includes(option))
-      .filter(option => {
-        if (query.length === 0) return option;
-        return option.toLowerCase().includes(query.toLowerCase());
-      });
+  const removeSkill = (skill: string) => {
+    setIsDropdownVisible(false);
+    updateSkills(skills.filter(s => s !== skill));
   };
 
-  const isDropdownOpen =
-    isDropdownVisible && getSkillsToShowInDropdown().length > 0;
+  // Options should not include already chosen skills
+  const skillOptions = allSkills.filter(skill => !skills.includes(skill));
 
   return (
     <Container>
@@ -76,30 +45,14 @@ const SkillsEditor = ({ updateSkills, skills }: Props) => {
           <Chip key={skill} text={skill} onToggle={removeSkill} />
         ))}
       </Skills>
-      <InnerContainer>
-        <SearchBar
-          isDisabled={isLoading}
-          hasOpenDropdown={isDropdownOpen}
-          onBlur={handleBlur}
-          onChange={setQuery}
-          onFocus={handleFocus}
-          placeholder={t('public.mentor.addSkill')}
-          value={query}
-          variant="small"
-        />
-        {isDropdownOpen && (
-          <Dropdown>
-            {getSkillsToShowInDropdown().map((option, index) => (
-              <DropdownItem
-                key={index}
-                onClick={() => handleOptionClick(option)}
-              >
-                <Text variant="menuOption">{option}</Text>
-              </DropdownItem>
-            ))}
-          </Dropdown>
-        )}
-      </InnerContainer>
+      <DropdownSearch
+        isDisabled={isLoading}
+        isDropdownVisible={isDropdownVisible}
+        options={skillOptions}
+        placeholder={t('public.mentor.addSkill')}
+        selectOption={addSkill}
+        setIsDropdownVisible={setIsDropdownVisible}
+      />
     </Container>
   );
 };
@@ -113,35 +66,6 @@ const Skills = styled.div`
   flex-wrap: wrap;
   gap: 1rem;
   margin-top: 0.5rem;
-`;
-
-const InnerContainer = styled.div`
-  margin: 1rem 0;
-  max-width: 350px;
-  position: relative;
-`;
-
-const Dropdown = styled.div`
-  background-color: white;
-  border: 1px solid ${palette.purple};
-  border-radius: 0 0 20px 20px;
-  box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.1);
-  box-sizing: border-box;
-  max-height: 200px;
-  outline: ${palette.purple} solid 2px;
-  overflow-y: auto;
-  position: absolute;
-  width: 100%;
-  z-index: 10;
-`;
-
-const DropdownItem = styled.div`
-  cursor: pointer;
-  padding: 0.5rem 1rem;
-
-  &:hover {
-    background-color: ${palette.blueLight};
-  }
 `;
 
 export default SkillsEditor;

--- a/src/features/ProfilePage/components/SkillsEditor.tsx
+++ b/src/features/ProfilePage/components/SkillsEditor.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 
 import { selectAllSkillOptions } from '@/features/MentorPage/selectors';
 import { useAppSelector } from '@/store';
+import { useGetMentorsQuery } from '@/features/MentorPage/mentorPageApi';
 
 import { Chip } from '@/components/Chip';
 import DropdownSearch from '@/components/DropdownSearch/DropdownSearch';
@@ -15,7 +16,13 @@ type Props = {
 
 const SkillsEditor = ({ updateSkills, skills }: Props) => {
   const { t } = useTranslation('profile');
-  const skillOptions = useAppSelector(selectAllSkillOptions());
+
+  // This should be run before all skill options are selected
+  useGetMentorsQuery();
+
+  const allSkills = useAppSelector(selectAllSkillOptions());
+  // Options should not include already chosen skills
+  const skillOptions = allSkills.filter(s => !skills.includes(s));
 
   const addSkill = (skill: string) => updateSkills([...skills, skill]);
 
@@ -31,7 +38,7 @@ const SkillsEditor = ({ updateSkills, skills }: Props) => {
         ))}
       </Skills>
       <DropdownSearch
-        options={skillOptions.filter(so => !skills.includes(so))} // Options should not include already chosen skills
+        options={skillOptions}
         placeholder={t('public.mentor.addSkill')}
         selectOption={addSkill}
       />

--- a/src/features/ProfilePage/components/SkillsEditor.tsx
+++ b/src/features/ProfilePage/components/SkillsEditor.tsx
@@ -1,8 +1,7 @@
 import styled from 'styled-components';
-import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { selectSkills } from '@/features/MentorPage/selectors';
+import { selectAllSkillOptions } from '@/features/MentorPage/selectors';
 import { useAppSelector } from '@/store';
 
 import { Chip } from '@/components/Chip';
@@ -11,15 +10,23 @@ import DropdownSearch from '@/components/DropdownSearch/DropdownSearch';
 import Text from '@/components/Text';
 
 type Props = {
+  onChange: (value: string[]) => void;
   skills: string[];
 };
 
-const SkillsEditor = ({ skills }: Props) => {
+const SkillsEditor = ({ onChange, skills }: Props) => {
   const { t } = useTranslation('profile');
 
-  const skillSelection = useAppSelector(selectSkills());
+  const skillSelection = useAppSelector(selectAllSkillOptions());
 
-  const [skillSearchValue, setSkillSearchValue] = useState('');
+  const addSkill = (skill: string) => {
+    onChange([...skills, skill]);
+  };
+
+  const removeSkill = (skill: string) => {
+    const updatedSkills = skills.filter(s => s !== skill);
+    onChange(updatedSkills);
+  };
 
   return (
     <>
@@ -31,16 +38,15 @@ const SkillsEditor = ({ skills }: Props) => {
             text={skill}
             isSelected={true}
             shouldShake={false}
-            onToggle={() => null}
+            onToggle={removeSkill}
           />
         ))}
       </Skills>
       <SearchBar>
         <DropdownSearch
-          onChange={setSkillSearchValue}
+          addSkill={addSkill}
           options={skillSelection}
           placeholder={t('public.mentor.addSkill')}
-          value={skillSearchValue}
         />
       </SearchBar>
     </>

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,8 +1,5 @@
 import { Status } from '@/features/MentorPage/components/MentorList/MentorCard/List/Tag';
 
-export const capitalize = (str: string) =>
-  str.charAt(0).toUpperCase() + str.slice(1);
-
 export const getIsOlderThanDaysAgo = (daysAgo: number, compareTime: number) => {
   const timestampDaysAgo = new Date().getTime() - daysAgo * 24 * 60 * 60 * 1000;
   return compareTime > timestampDaysAgo;


### PR DESCRIPTION
# Description

- Mentors' skills are displayed on the Profile page.
- Mentor can search for skills using the dropdown search.
- Mentor can add and remove skills.

Fixes Trello tasks: 
- [Profile page mentor skills: displaying, searching, adding and removing skills](https://trello.com/c/1St9pc7R/977-profile-page-mentor-skills-displaying-searching-adding-and-removing-skills)
- [Flaky mentor e2e test](https://trello.com/c/L7w8wjJS/995-flaky-mentor-e2e-test)

## Why was the change made?

Mentors need to be able to add and remove skills from their profile.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] Unittest
- [x] Cypress e2e -tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
