### PR TITLE
Make newest mentor cards scrollable in mobile view

### DIFF
--- a/cypress/tests/mentor.cy.ts
+++ b/cypress/tests/mentor.cy.ts
@@ -97,6 +97,7 @@ describe('mentor profile', () => {
 
     // check that values were updated
     cy.reload();
+    cy.switchLanguageAfterLogin('fi');
     cy.getInputByLabel('Julkinen nimimerkki *').should(
       'have.value',
       NEW_DISPLAY_NAME,

--- a/src/features/HomePage/components/NewestMentors.tsx
+++ b/src/features/HomePage/components/NewestMentors.tsx
@@ -86,7 +86,9 @@ const MentorCards = styled.div<{ isMobile: boolean }>`
   ${({ isMobile }) =>
     isMobile &&
     css`
-      flex: 1;
+      gap: 1.5rem;
+      margin: auto -1rem auto -1rem;
+      overflow: auto;
       scroll-snap-type: x mandatory;
       white-space: nowrap;
       &::-webkit-scrollbar {


### PR DESCRIPTION
# Description
Newest mentors mentorcards are now scrollable, and users can see both cards also in mobile view. 

- [Ticket](https://trello.com/c/oD9OIVg1/990-bugfix-make-newest-mentors-scrollable-in-mobile-view)

## Why was the change made?

Newest mentors mentorcards were not scrollable in mobile view and therefore users could not access the feature correctly.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Unittest
- [X] Cypress e2e -tests

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
