### PR TITLE
Fix license bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "test:unit": "jest",
     "test:e2e": "npm run wait && cypress run",
     "test": "npm run test:unit && npm run test:e2e",
-    "build": "webpack",
-    "start": "webpack serve --open",
+    "build": "npm run licensesjson:create && webpack",
+    "start": "npm run licensesjson:create && webpack serve --open",
     "wait": "wait-on http://localhost:8080/version && wait-on http://localhost:8082"
   },
   "author": "",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -80,9 +80,12 @@ module.exports = {
           from: 'register/**/*',
           context: path.resolve(__dirname, 'src'),
         },
+        {
+          from: path.resolve(__dirname, 'licenses.json'),
+          to: path.resolve(__dirname, 'dist'),
+        },
       ],
     }),
-
     new webpack.DefinePlugin({
       COMMIT_HASH: JSON.stringify(commitHash),
     }),


### PR DESCRIPTION
# Description

Licenses are now created when running `npm run start` and `npm run build`, so licenses are included in builds and generate now warnings. Licenses are copied to dist folder.

Fixes # (issue)

## Why was the change made?

Licenses were missing from build.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unittest
- [x] Cypress e2e -tests

# Caveats?

Does this introduce new warnings or are linter rules suppressed? Why? Is only manual testing applicable for this feature? Is there something special that the reviewer should take into account?

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
