### PR TITLE
Use webrefresh

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 dist/
 node_modules/
+licenses.json

--- a/src/features/Authentication/userSlice.ts
+++ b/src/features/Authentication/userSlice.ts
@@ -36,8 +36,6 @@ export const user = createSlice({
         (_, { payload }) => payload,
       )
       .addMatcher(authenticationApi.endpoints.logout.matchFulfilled, () => {
-        sessionStorage.removeItem('refresh_token');
-        sessionStorage.removeItem('access_token');
         window.location.href = '/login/';
         return initialState;
       });

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -7,7 +7,6 @@ import {
   FetchBaseQueryError,
   fetchBaseQuery,
 } from '@reduxjs/toolkit/dist/query';
-import { authenticationApi } from '@/features/Authentication/authenticationApi';
 
 const parse =
   <A, B>(model: D.Decoder<A, B>, onError?: (error: D.DecodeError) => void) =>
@@ -61,8 +60,7 @@ export const refreshingBaseQuery: BaseQueryFn<
       return await baseQuery(args, api, extraOptions);
     } else {
       // if refresh fail, logout
-      api.dispatch(authenticationApi.endpoints.logout.initiate());
-      return { data: result.data };
+      window.location.href = '/login/';
     }
   }
 

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -35,17 +35,6 @@ export const parseAndTransformTo = <A, B, C>(
 
 const baseQuery = fetchBaseQuery({
   baseUrl: '/api',
-  prepareHeaders: headers => {
-    const accessToken = sessionStorage.getItem('access_token');
-    if (accessToken) {
-      headers.set('Authorization', `Bearer ${accessToken}`);
-    }
-    return headers;
-  },
-});
-
-const refreshResponse = D.struct({
-  access_token: D.string,
 });
 
 export const refreshingBaseQuery: BaseQueryFn<
@@ -58,25 +47,16 @@ export const refreshingBaseQuery: BaseQueryFn<
   // if unauthorized try to refresh
   const isUnauthorized = result.error && result.error.status === 401;
   if (isUnauthorized) {
-    const refresh_token = sessionStorage.getItem('refresh_token');
     const refreshResult = await baseQuery(
       {
-        url: 'refresh',
-        method: 'POST',
-        body: JSON.stringify({ refresh_token }),
+        url: 'webrefresh',
+        method: 'GET',
       },
       api,
       extraOptions,
     );
 
-    if (refreshResult.data) {
-      const token = parseAndTransformTo(
-        refreshResult.data,
-        refreshResponse,
-        { access_token: '' },
-        ({ access_token }) => access_token,
-      );
-      sessionStorage.setItem('access_token', token);
+    if (refreshResult.meta?.response?.ok) {
       // retry the initial query
       return await baseQuery(args, api, extraOptions);
     } else {


### PR DESCRIPTION
# Description

Use webrefresh to refresh token
Here is the [API PR](https://gitlab.com/ylitse/ylitse-api/-/merge_requests/80) 
[Trello-ticket](https://trello.com/c/XfxGaRjH/979-implement-webrefresh-flow)

## Why was the change made?

When using app, user should not be thrown out, but access refreshed


See recording how it works in action
(accesstoken ttl 5 sec, refreshtoken ttl 15 sec)


https://github.com/user-attachments/assets/d4ec378c-648d-4f68-949e-c7b2bd38a485




## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I tested this by setting minimal token lifetime and saw that after access was invalid, then the refresh-flow worked

- [ ] Unittest
- [ ] Cypress e2e -tests
- [x] manual testing

# Caveats?

NA

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
