### PR TITLE
Change block and archive texts

### DIFF
--- a/cypress/tests/chat.cy.ts
+++ b/cypress/tests/chat.cy.ts
@@ -224,7 +224,7 @@ describe('chat', () => {
     // unarchive chat
     cy.getByText('Palauta keskustelu', 'button').click();
     cy.contains(
-      `Haluatko palauttaa keskustelun käyttäjän ${mentee.displayName} kanssa?`,
+      `Haluatko palauttaa keskustelun arkistosta käyttäjän ${mentee.displayName} kanssa?`,
     ).should('be.visible');
     cy.get('button[id="confirm-restore"]').click();
 
@@ -311,11 +311,11 @@ describe('chat', () => {
     cy.contains('Kirjoita viestisi tähän').should('not.exist');
 
     // unarchive chat
-    cy.getByText('Palauta keskustelu', 'button').click();
+    cy.getByText('Poista esto', 'button').click();
     cy.contains(
-      `Haluatko palauttaa keskustelun käyttäjän ${mentee.displayName} kanssa?`,
+      `Haluatko poistaa eston ja palauttaa keskustelun käyttäjän ${mentee.displayName} kanssa?`,
     ).should('be.visible');
-    cy.get('button[id="confirm-restore"]').click();
+    cy.get('button[id="confirm-unblock"]').click();
 
     // should show notification
     cy.contains('Keskustelu palautettu onnistuneesti').should('be.visible');

--- a/src/features/Chat/components/ActiveWindow/Header/DesktopButtons.tsx
+++ b/src/features/Chat/components/ActiveWindow/Header/DesktopButtons.tsx
@@ -9,7 +9,7 @@ import { ICON_SIZES } from '@/components/constants';
 
 import type { ChatBuddy } from '@/features/Chat/mappers';
 
-type DialogVariant = 'archive' | 'block' | 'restore';
+type DialogVariant = 'archive' | 'block' | 'restore' | 'unblock';
 
 type Props = {
   chat: ChatBuddy;
@@ -28,10 +28,11 @@ const DesktopButtons = ({
   const openArchiveDialog = () => confirmStatusChange('archive');
   const openBlockDialog = () => confirmStatusChange('block');
   const openRestoreDialog = () => confirmStatusChange('restore');
+  const openUnblockDialog = () => confirmStatusChange('unblock');
 
   return (
     <Container>
-      {chat.status === 'ok' ? (
+      {chat.status === 'ok' && (
         <>
           <StatusButton
             onClick={openArchiveDialog}
@@ -44,11 +45,19 @@ const DesktopButtons = ({
             text={t('header.block')}
           />
         </>
-      ) : (
+      )}
+      {chat.status === 'archived' && (
         <StatusButton
           onClick={openRestoreDialog}
           icon="return"
           text={t('header.restore')}
+        />
+      )}
+      {chat.status === 'banned' && (
+        <StatusButton
+          onClick={openUnblockDialog}
+          icon="return"
+          text={t('header.unblock')}
         />
       )}
       {isMentee && (

--- a/src/features/Chat/components/ActiveWindow/Header/TabletButtons.tsx
+++ b/src/features/Chat/components/ActiveWindow/Header/TabletButtons.tsx
@@ -13,7 +13,7 @@ import { ICON_SIZES, palette } from '@/components/constants';
 // Components
 import { Button, IconButton, StatusButton } from '@/components/Buttons';
 
-type DialogVariant = 'archive' | 'block' | 'restore';
+type DialogVariant = 'archive' | 'block' | 'restore' | 'unblock';
 
 type Props = {
   chat: ChatBuddy;
@@ -50,7 +50,7 @@ const TabletButtons = ({
       />
       {isDropdownOpen && (
         <Dropdown>
-          {chat.status === 'ok' ? (
+          {chat.status === 'ok' && (
             <>
               <TabletStatusButton
                 onClick={() => confirmAction('archive')}
@@ -63,11 +63,19 @@ const TabletButtons = ({
                 text={t('header.block')}
               />
             </>
-          ) : (
+          )}
+          {chat.status === 'archived' && (
             <TabletStatusButton
               onClick={() => confirmAction('restore')}
               icon="return"
               text={t('header.restore')}
+            />
+          )}
+          {chat.status === 'banned' && (
+            <TabletStatusButton
+              onClick={() => confirmAction('unblock')}
+              icon="return"
+              text={t('header.unblock')}
             />
           )}
           <ReportButton

--- a/src/features/Chat/components/ActiveWindow/Header/index.tsx
+++ b/src/features/Chat/components/ActiveWindow/Header/index.tsx
@@ -34,7 +34,7 @@ import Text from '@/components/Text';
 import type { ChatBuddy } from '@/features/Chat/mappers';
 import type { ChatFolder } from '@/features/Chat/chatPageApi';
 
-type DialogVariant = 'archive' | 'block' | 'restore';
+type DialogVariant = 'archive' | 'block' | 'restore' | 'unblock';
 
 const confirmDialogMap: Record<
   DialogVariant,
@@ -43,6 +43,7 @@ const confirmDialogMap: Record<
   archive: { borderColor: palette.orange, targetFolder: 'archived' },
   block: { borderColor: palette.redSalmon, targetFolder: 'banned' },
   restore: { borderColor: palette.blue2, targetFolder: 'ok' },
+  unblock: { borderColor: palette.redSalmon, targetFolder: 'ok' },
 };
 
 const iconMap = {

--- a/src/static/locales/en/chat.json
+++ b/src/static/locales/en/chat.json
@@ -8,7 +8,7 @@
     "block": {
       "confirm": "Block user",
       "description": "Do you want to block user {{buddyName}}?",
-      "title": "Blocking user"
+      "title": "Block user"
     },
     "cancel": "Cancel",
     "report": {
@@ -30,9 +30,9 @@
       "title": "Report user"
     },
     "restore": {
-      "confirm": "Restore conversation",
-      "description": "Do you want to restore the conversation with {{buddyName}}?",
-      "title": "Restoring conversation"
+      "confirm": "Unarchive",
+      "description": "Do you want to unarchive and restore the conversation with {{buddyName}}?",
+      "title": "Unarchive conversation"
     },
     "unblock": {
       "confirm": "Unblock",
@@ -44,7 +44,7 @@
     "archive": "Archive",
     "block": "Block user",
     "report": "Report",
-    "restore": "Restore conversation",
+    "restore": "Unarchive",
     "search": "Search conversation",
     "unblock": "Unblock"
   },

--- a/src/static/locales/en/chat.json
+++ b/src/static/locales/en/chat.json
@@ -33,6 +33,11 @@
       "confirm": "Restore conversation",
       "description": "Do you want to restore the conversation with {{buddyName}}?",
       "title": "Restoring conversation"
+    },
+    "unblock": {
+      "confirm": "Unblock",
+      "description": "Do you want to unblock {{buddyName}} and restore the conversation?",
+      "title": "Unblock"
     }
   },
   "header": {
@@ -40,7 +45,8 @@
     "block": "Block user",
     "report": "Report",
     "restore": "Restore conversation",
-    "search": "Search conversation"
+    "search": "Search conversation",
+    "unblock": "Unblock"
   },
   "input": {
     "placeholder": "Write your message here"

--- a/src/static/locales/fi/chat.json
+++ b/src/static/locales/fi/chat.json
@@ -30,8 +30,8 @@
       "title": "Ilmianna käyttäjä"
     },
     "restore": {
-      "confirm": "Palauta keskustelu",
-      "description": "Haluatko palauttaa keskustelun käyttäjän {{buddyName}} kanssa?",
+      "confirm": "Palauta arkistosta",
+      "description": "Haluatko palauttaa keskustelun arkistosta käyttäjän {{buddyName}} kanssa?",
       "title": "Keskustelun palauttaminen"
     },
     "unblock": {

--- a/src/static/locales/fi/chat.json
+++ b/src/static/locales/fi/chat.json
@@ -33,6 +33,11 @@
       "confirm": "Palauta keskustelu",
       "description": "Haluatko palauttaa keskustelun käyttäjän {{buddyName}} kanssa?",
       "title": "Keskustelun palauttaminen"
+    },
+    "unblock": {
+      "confirm": "Poista esto",
+      "description": "Haluatko poistaa eston ja palauttaa keskustelun käyttäjän {{buddyName}} kanssa?",
+      "title": "Poista esto"
     }
   },
   "header": {
@@ -40,7 +45,8 @@
     "block": "Estä käyttäjä",
     "report": "Ilmianna",
     "restore": "Palauta keskustelu",
-    "search": "Etsi keskustelusta"
+    "search": "Etsi keskustelusta",
+    "unblock": "Poista esto"
   },
   "input": {
     "placeholder": "Kirjoita viestisi tähän"


### PR DESCRIPTION
# Description
Fixed misleading texts when user is blocked. New changes are more explicit about the action made. I have added new dialog variant 'unblock', so now user knows when they are unblocking someone rather than just restoring conversation. It is still told that if user decides to unblock the other user, conversation will be restored. 

- [Ticket](https://trello.com/c/kcfFBJFW/1016-change-block-and-archive-button-and-confirmation-texts)

Fixes # Misleading texts when unblocking user

## Why was the change made?

Texts should be explicit about actions

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Unittest
- [X] Cypress e2e -tests

# Caveats?

Does this introduce new warnings or are linter rules suppressed? Why? Is only manual testing applicable for this feature? Is there something special that the reviewer should take into account?

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
