### PR TITLE
Navigate away from the chat after it has been blocked

### DIFF
--- a/cypress/tests/chat.cy.ts
+++ b/cypress/tests/chat.cy.ts
@@ -313,7 +313,7 @@ describe('chat', () => {
 
     // go to the blocked chat
     cy.get('button[aria-label="menuLines"]').click();
-    cy.getByText('Estetyt keskustelut', 'a');
+    cy.getByText('Estetyt keskustelut', 'a').click();
     cy.getByText(mentee.displayName, 'p').click();
 
     // unblock chat
@@ -380,7 +380,7 @@ describe('chat', () => {
     // go to blocked conversations
     cy.get('[href="/chat"]').click();
     cy.get('button[aria-label="menuLines"]').click();
-    cy.getByText('Estetyt keskustelut', 'a');
+    cy.getByText('Estetyt keskustelut', 'a').click();
     cy.get('div[aria-label="unseen-messages-dot"]').should('not.exist');
   });
 });

--- a/cypress/tests/chat.cy.ts
+++ b/cypress/tests/chat.cy.ts
@@ -307,10 +307,16 @@ describe('chat', () => {
     // should show notification
     cy.contains('Keskustelu estetty onnistuneesti').should('be.visible');
 
-    // should not have message field anymore
-    cy.contains('Kirjoita viestisi tähän').should('not.exist');
+    // should not show chat anymore
+    cy.contains(mentee.displayName).should('not.exist');
+    cy.getByText(message, 'p').should('not.exist');
 
-    // unarchive chat
+    // go to the blocked chat
+    cy.get('button[aria-label="menuLines"]').click();
+    cy.getByText('Estetyt keskustelut', 'a');
+    cy.getByText(mentee.displayName, 'p').click();
+
+    // unblock chat
     cy.getByText('Poista esto', 'button').click();
     cy.contains(
       `Haluatko poistaa eston ja palauttaa keskustelun käyttäjän ${mentee.displayName} kanssa?`,

--- a/src/features/Chat/components/ActiveWindow/Header/index.tsx
+++ b/src/features/Chat/components/ActiveWindow/Header/index.tsx
@@ -86,11 +86,12 @@ const Header = ({ chat }: Props) => {
       title: t(`dialog.${variant}.title`),
     });
     if (isConfirmed) {
-      updateChatStatus({
+      await updateChatStatus({
         userId,
         buddyId: chat.buddyId,
         status: confirmDialogMap[variant].targetFolder,
-      });
+      }).unwrap();
+      if (variant === 'block') dispatch(clearActiveChat());
     }
   };
 


### PR DESCRIPTION
# Description

- Chat is closed after user has blocked it.
- Fixes test _will not show unseen dot for new messages in blocked conversation_.

Fixes [Navigate away from the chat after it has been blocked](https://trello.com/c/fwhaKw86/1015-navigate-away-from-the-chat-after-it-has-been-blocked)

## Why was the change made?

We don't want the user to see further messages from a contact they have blocked.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unittest
- [x] Cypress e2e -tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
