### PR TITLE
Mentor should not be able to discuss with themselves (Client)

### DIFF
--- a/cypress/tests/chat.cy.ts
+++ b/cypress/tests/chat.cy.ts
@@ -35,6 +35,18 @@ describe('chat', () => {
     });
   };
 
+  it('mentor can not start a conversation with themselves', () => {
+    api.signUpMentor(mentor);
+    cy.loginUser(mentor.loginName, mentor.password);
+
+    // go to mentors page
+    cy.get('[href="/mentors"]').click();
+    cy.getByText(mentor.displayName, 'h2').should('be.visible');
+
+    cy.getByText('Avaa kortti', 'button').scrollIntoView().click();
+    cy.getByText('Aloita keskustelu', 'button').should('be.disabled');
+  });
+
   it('can start a conversation with mentor', () => {
     api.signUpMentee(mentee);
     api.signUpMentor(mentor);

--- a/src/features/MentorPage/components/MentorList/MentorCard/Expanded/Content.tsx
+++ b/src/features/MentorPage/components/MentorList/MentorCard/Expanded/Content.tsx
@@ -23,7 +23,7 @@ type Props = {
 };
 
 export const Content = ({
-  mentor: { skills, story, languages, buddyId, name, mentorId },
+  mentor: { skills, story, languages, buddyId, name },
   onDismiss,
 }: Props) => {
   const { isMobile } = useGetLayoutMode();
@@ -31,6 +31,7 @@ export const Content = ({
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
   const currentUserId = useAppSelector(selectUserId);
+  const isMe = currentUserId === buddyId;
 
   const handleClick = () => {
     dispatch(setConversation({ name, buddyId }));
@@ -53,14 +54,14 @@ export const Content = ({
       </StoryHeader>
       <Text>{story}</Text>
       {isMobile && (
-        <Languages
-          isMe={currentUserId === mentorId}
-          languages={languages}
-          isMobile={isMobile}
-        />
+        <Languages isMe={isMe} languages={languages} isMobile={isMobile} />
       )}
       <Skills skills={skills} />
-      <OpenConversationButton onClick={handleClick}>
+      <OpenConversationButton
+        isDisabled={isMe}
+        onClick={handleClick}
+        variant={isMe ? 'disabled' : 'dark'}
+      >
         {t('card.chat')}
       </OpenConversationButton>
     </Container>


### PR DESCRIPTION
# Description

- Disable _Start conversation_ button on mentor's own profile card.
- Fix desktop mentor card languages styling by using the correct mentor id in the code.

Fixes [Mentor should not be able to discuss with themselves (Client)](https://trello.com/c/TQOyfvmF/1014-mentor-should-not-be-able-to-discuss-with-themselves-client)

## Why was the change made?

We don't want to allow mentors starting conversations with themselves.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unittest
- [x] Cypress e2e -tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
