### PR TITLE
Hide pagination buttons if there is only one page in mentor search

### DIFF
--- a/src/features/MentorPage/components/MentorsFilter/Skills/BottomBar/index.tsx
+++ b/src/features/MentorPage/components/MentorsFilter/Skills/BottomBar/index.tsx
@@ -24,13 +24,14 @@ export const BottomBar = ({
   skillsInPage,
   setSkillsInPage,
 }: Props) => {
+  const dispatch = useAppDispatch();
+  const { t } = useTranslation('mentors');
+
   const paginationRange = usePagination({
     currentPage,
     pageSize: skillsInPage,
     totalCount: skillTotalAmount,
   });
-  const dispatch = useAppDispatch();
-  const { t } = useTranslation('mentors');
 
   const handleReset = () => {
     dispatch(resetFilters());
@@ -44,6 +45,7 @@ export const BottomBar = ({
 
   const isLastPage = currentPage === paginationRange?.slice(-1)[0];
   const isFirstPage = currentPage === paginationRange?.[0];
+  const isPaginated = paginationRange ? paginationRange.length > 1 : false;
 
   return (
     <Container>
@@ -67,14 +69,15 @@ export const BottomBar = ({
           />
         )}
 
-        {paginationRange?.map((page, index) => (
-          <PageButton
-            key={`${page}_${index}`}
-            isSelected={currentPage === page}
-            page={page}
-            onClick={() => setCurrentPage(Number(page))}
-          />
-        ))}
+        {isPaginated &&
+          paginationRange?.map((page, index) => (
+            <PageButton
+              key={`${page}_${index}`}
+              isSelected={currentPage === page}
+              page={page}
+              onClick={() => setCurrentPage(Number(page))}
+            />
+          ))}
         {!isLastPage && (
           <Next
             variant="next"

--- a/src/features/MentorPage/components/MentorsFilter/index.tsx
+++ b/src/features/MentorPage/components/MentorsFilter/index.tsx
@@ -1,21 +1,20 @@
+import styled from 'styled-components';
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 
-import { selectSkills } from '../../selectors';
 import {
   changeSearchString,
   selectSearchString,
 } from '@/features/MentorPage/mentorsFilterSlice';
+import { selectSkills } from '@/features/MentorPage/selectors';
 import { useAppSelector, useAppDispatch } from '@/store';
-
 import { useGetLayoutMode } from '@/hooks/useGetLayoutMode';
-import { useTranslation } from 'react-i18next';
 
-import styled from 'styled-components';
-import { palette } from '@/components/constants';
-import { Text } from '@/components/Text/Text';
 import DesktopSearch from './MentorSearch';
 import MobileSearch from './MobileSearch';
+import { palette } from '@/components/constants';
 import Skills from './Skills';
+import { Text } from '@/components/Text/Text';
 
 const MentorsFilter = () => {
   const [isSkillFilterExpanded, setIsSKillFilterExpanded] = useState(false);


### PR DESCRIPTION
# Description

Fixes [Hide pagination buttons if there is only one page in mentor search](https://trello.com/c/p6psWul0/1019-hide-pagination-buttons-if-there-is-only-one-page-in-mentor-search)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unittest
- [ ] Cypress e2e -tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
