### PR TITLE
Keep message whitespace when displaying it to the user

### DIFF
--- a/src/features/Chat/components/ActiveWindow/Message.tsx
+++ b/src/features/Chat/components/ActiveWindow/Message.tsx
@@ -80,6 +80,7 @@ const Bubble = styled.div<{
 
 const Content = styled(Text)`
   margin: 0;
+  white-space: pre-wrap;
 `;
 
 const Timestamp = styled(Text)<{ isSent: boolean }>`


### PR DESCRIPTION
# Description

- Respect message whitespace when displaying them. 

Fixes [Whitespace is ignored when rendering chat messages](https://trello.com/c/LSSECt0X/1021-whitespace-is-ignored-when-rendering-chat-messages)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unittest
- [ ] Cypress e2e -tests

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
