### PR TITLE
Prohibit sending empty chat messages

### DIFF
--- a/cypress/tests/chat.cy.ts
+++ b/cypress/tests/chat.cy.ts
@@ -74,6 +74,19 @@ describe('chat', () => {
     cy.getByText('Hello there', 'p').should('be.visible');
   });
 
+  it('send button is disabled if input is only whitespace', () => {
+    const message = 'I would like to talk to you';
+    signUpAndMessageMentor(message);
+
+    cy.loginUser(mentor.loginName, mentor.password);
+
+    cy.get('[href="/chat"]').click();
+    cy.get('textarea[placeholder*="Kirjoita viestisi tähän"]')
+      .click()
+      .type(' ');
+    cy.get('button[aria-label="send"]').should('be.disabled');
+  });
+
   it('can send message to existing conversation', () => {
     const message = 'I would like to talk to you';
     const answer = 'How can I help you';

--- a/src/features/Chat/components/ActiveWindow/MessageField.tsx
+++ b/src/features/Chat/components/ActiveWindow/MessageField.tsx
@@ -32,7 +32,8 @@ const MessageField = ({ chat }: Props) => {
     if (!userId || isLoadingNewMessage) return;
 
     setIsLoadingNewMessage(true);
-    const message = toSendMessage(buddyId, userId, text);
+    const trimmedText = text.trim();
+    const message = toSendMessage(buddyId, userId, trimmedText);
 
     try {
       await sendMessage({ userId, message }).unwrap();

--- a/src/features/Chat/components/ActiveWindow/MessageField.tsx
+++ b/src/features/Chat/components/ActiveWindow/MessageField.tsx
@@ -49,6 +49,8 @@ const MessageField = ({ chat }: Props) => {
     }
   }, [chat.messages]);
 
+  const isSendingDisabled = isLoadingNewMessage || text.trim().length < 1;
+
   return (
     <Container>
       <Input
@@ -62,7 +64,7 @@ const MessageField = ({ chat }: Props) => {
       />
       <SendButton
         variant="send"
-        isDisabled={isLoadingNewMessage}
+        isDisabled={isSendingDisabled}
         sizeInPx={ICON_SIZES.HUGE}
         onClick={() => handleMessageSend(chat.buddyId, text)}
       />


### PR DESCRIPTION
# Description

- Trim leading and trailing whitespace before sending message
- Disable sending if text field does not have any non-whitespace characters
- Add e2e test

Fixes [Prohibit sending empty chat messages](https://trello.com/c/NVotSqEE/1042-prohibit-sending-empty-chat-messages)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unittest
- [x] Cypress e2e -tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
