### PR TITLE
Change localization age-limit 15 to 17 year old

### DIFF
--- a/src/static/locales/en/register.json
+++ b/src/static/locales/en/register.json
@@ -1,7 +1,7 @@
 {
   "accountInfoTitle": "Account information",
   "apuuLink": "the Apuu chat.",
-  "description": "Great that you want to start using the application. Please notice that the application is meant for people who are at least 15. If you're under 15, please visit",
+  "description": "Great that you want to start using the application. Please notice that the application is meant for people who are at least 17. If you're under 17, please visit",
   "displayNameFieldInfo": "Provided a display name that can't be identified, if you want to use the application anonymously.",
   "displayNameLabel": "Display name *",
   "displayNameTooShortError": "Display name is too short",
@@ -27,7 +27,7 @@
   "privacyTitle": "Privacy",
   "registerButton": "Register",
   "registerTitle": "Register",
-  "requiredAgeSwitch": "I'm at least 15 years old",
+  "requiredAgeSwitch": "I'm at least 17 years old",
   "requiredFieldInfo": "Fields marked with a star * are required.",
   "showPassword": "Show password",
   "submitError": "Form submission failed. Please try again in a moment.",

--- a/src/static/locales/fi/register.json
+++ b/src/static/locales/fi/register.json
@@ -1,7 +1,7 @@
 {
   "accountInfoTitle": "Tilin tiedot",
   "apuuLink": "Apuu-chatissa.",
-  "description": "Hienoa, että haluat aloittaa palvelun käytön. Huomaathan, että palvelu on tarkoitettu vähintään 15-vuotiaille. Jos olet alle 15-vuotias, vieraile",
+  "description": "Hienoa, että haluat aloittaa palvelun käytön. Huomaathan, että palvelu on tarkoitettu vähintään 17-vuotiaille. Jos olet alle 17-vuotias, vieraile",
   "displayNameFieldInfo": "Syötä nimimerkki, josta sinua ei voi tunnistaa, jos haluat käyttää palvelua anonyymisti.",
   "displayNameLabel": "Julkinen nimimerkki *",
   "displayNameTooShortError": "Nimimerkki on liian lyhyt",
@@ -27,7 +27,7 @@
   "privacyTitle": "Yksityisyydensuoja",
   "registerButton": "Rekisteröidy",
   "registerTitle": "Rekisteröidy",
-  "requiredAgeSwitch": "Olen vähintään 15-vuotias",
+  "requiredAgeSwitch": "Olen vähintään 17-vuotias",
   "requiredFieldInfo": "Tähdellä * merkityt kentät ovat pakollisia.",
   "showPassword": "Näytä salasana",
   "submitError": "Lomakkeen lähettäminen epäonnistui. Yritä hetken kuluttua uudelleen.",


### PR DESCRIPTION
# Description

Changed text in registration page.
The service is meant for people over 17 years of age, not 15

Fixes # ([issue](https://trello.com/c/KpxF7GsC/1070-fix-register-page-age-limit-in-the-switch-button-15-17))

## Why was the change made?

Correct service information

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unittest
- [ ] Cypress e2e -tests

# Caveats?

Does this introduce new warnings or are linter rules suppressed? Why? Is only manual testing applicable for this feature? Is there something special that the reviewer should take into account?

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
