### PR TITLE
Disable start-conversation-button if vacationing mentor

### DIFF
--- a/src/features/MentorPage/components/MentorList/MentorCard/Expanded/Content.tsx
+++ b/src/features/MentorPage/components/MentorList/MentorCard/Expanded/Content.tsx
@@ -23,7 +23,7 @@ type Props = {
 };
 
 export const Content = ({
-  mentor: { skills, story, languages, buddyId, name },
+  mentor: { skills, story, languages, buddyId, name, isVacationing },
   onDismiss,
 }: Props) => {
   const { isMobile } = useGetLayoutMode();
@@ -39,6 +39,7 @@ export const Content = ({
   };
 
   const areLanguagesDisplayed = isMobile && languages.length > 0;
+  const isStartingConversationDisabled = isMe || isVacationing;
 
   return (
     <Container isMobile={isMobile}>
@@ -58,10 +59,10 @@ export const Content = ({
       )}
       <Skills skills={skills} />
       <OpenConversationButton
-        isDisabled={isMe}
+        isDisabled={isStartingConversationDisabled}
         onClick={handleClick}
         size="large"
-        variant={isMe ? 'disabled' : 'dark'}
+        variant={isStartingConversationDisabled ? 'disabled' : 'dark'}
       >
         {t('card.chat')}
       </OpenConversationButton>


### PR DESCRIPTION
# Description

If starting a conversation, disable the button if mentor is on vacation-mode.
Existing conversations are not affected

Fixes # ([issue](https://trello.com/c/yKCgbkBM/1056-actor-can-start-a-chat-with-a-vacationing-absent-mentor))

## Why was the change made?

Bug fix

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unittest
- [ ] Cypress e2e -tests

# Caveats?

Does this introduce new warnings or are linter rules suppressed? Why? Is only manual testing applicable for this feature? Is there something special that the reviewer should take into account?

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
