### PR TITLE
Remove auto-scroll on new messages

### DIFF
--- a/src/features/Chat/components/ActiveWindow/MessageList.tsx
+++ b/src/features/Chat/components/ActiveWindow/MessageList.tsx
@@ -48,8 +48,6 @@ const MessageList = ({ messageList, status, buddyId, isLoading }: Props) => {
 
   const dispatch = useAppDispatch();
   const oldestMessage = messageList.length > 0 ? messageList[0].id : '0';
-  const newestMessage =
-    messageList.length > 0 ? messageList[messageList.length - 1].id : '0';
 
   const handleFetchOlderMessages = (messageId: string, buddyId: string) => {
     if (isLoading) {
@@ -69,7 +67,7 @@ const MessageList = ({ messageList, status, buddyId, isLoading }: Props) => {
     historyRef.current?.lastElementChild?.scrollIntoView({
       behavior: 'smooth',
     });
-  }, [newestMessage]);
+  }, []);
 
   useEffect(() => {
     if (isScrolledToTop) {


### PR DESCRIPTION
# Description

Remove auto-scroll on new messages because of a bug ( if user scrolls the conversation themselves auto-scroll will scroll to the middle of the container when new messages come )
- Still auto-scroll on initial opening of the conversation
- When "you got new messages"-design for conversation is done, rework the scrolling logic

Fixes # ([issue](https://trello.com/c/Cj80tpKW/1068-disable-auto-scroll))


https://github.com/user-attachments/assets/3771b384-856d-4af7-87bb-0b5559478fa4



## Why was the change made?

Bug fix

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unittest
- [ ] Cypress e2e -tests

# Caveats?

Does this introduce new warnings or are linter rules suppressed? Why? Is only manual testing applicable for this feature? Is there something special that the reviewer should take into account?

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
