### PR TITLE
Fix overflowing concepts in mobile view

### DIFF
--- a/src/features/HomePage/components/Concepts.tsx
+++ b/src/features/HomePage/components/Concepts.tsx
@@ -16,12 +16,12 @@ const Concepts = ({ isMobile = false }: Props) => {
       <Text variant="h2">{t('concepts.title')}</Text>
       <Text>{t('concepts.description')} </Text>
       <InnerContainer>
-        <Concept>
+        <Concept isMobile={isMobile}>
           <Name variant="bold">{t('concepts.concept1.name')}</Name>
           <Equals>{t('concepts.equals')}</Equals>
           <Definition>{t('concepts.concept1.definition')}</Definition>
         </Concept>
-        <Concept>
+        <Concept isMobile={isMobile}>
           <Name variant="bold">{t('concepts.concept2.name')}</Name>
           <Equals>{t('concepts.equals')}</Equals>
           <Definition>
@@ -41,7 +41,7 @@ const Concepts = ({ isMobile = false }: Props) => {
             />
           </Definition>
         </Concept>
-        <Concept>
+        <Concept isMobile={isMobile}>
           <Name variant="bold">{t('concepts.concept3.name')}</Name>
           <Equals>{t('concepts.equals')}</Equals>
           <Definition>
@@ -95,10 +95,15 @@ const InnerContainer = styled.div`
   gap: 1rem;
 `;
 
-const Concept = styled.div`
+const Concept = styled.div<{ isMobile: boolean }>`
   background-color: ${palette.blueWhite};
   display: flex;
   padding: 1rem;
+  ${({ isMobile }) =>
+    isMobile &&
+    css`
+      flex-wrap: wrap;
+    `}
 `;
 
 const Name = styled(Text)`


### PR DESCRIPTION
# Description

Concepts texts were overflowing in mobile view. Fixed code so if text is too long it gets wrapped and stays inside of the container. Result:
<img width="200" alt="fixed-concepts" src="https://github.com/user-attachments/assets/92bb0a5e-d504-47fb-bb86-b10515a66984">


Fixes # ([issue](https://trello.com/c/q3MiFZL4/1097-concepts-text-overflowing-from-its-container-in-mobile-view))

## Why was the change made?

BugFix

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unittest
- [ ] Cypress e2e -tests

# Caveats?

Does this introduce new warnings or are linter rules suppressed? Why? Is only manual testing applicable for this feature? Is there something special that the reviewer should take into account?

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
