### PR TITLE
Set email as partial for accountCodec

### DIFF
--- a/cypress/fixtures/accounts.ts
+++ b/cypress/fixtures/accounts.ts
@@ -2,14 +2,14 @@ export type Mentee = {
   loginName: string;
   displayName: string;
   password: string;
-  email: string;
+  email?: string;
   role: 'mentee';
 };
 export type Mentor = {
   loginName: string;
   displayName: string;
   password: string;
-  email: string;
+  email?: string;
   role: 'mentor';
   birthYear: number;
   phone: string;
@@ -43,6 +43,13 @@ const mentees: Array<Mentee> = [
     displayName: 'mentee_seppo',
     password: 'Menteementee!',
     email: 'mentee2@mentee.mentee',
+    role: 'mentee',
+  },
+  {
+    loginName: 'userNoEmail',
+    displayName: 'user_no_email',
+    password: 'usernoemail1',
+    email: undefined,
     role: 'mentee',
   },
 ];

--- a/cypress/tests/login.cy.ts
+++ b/cypress/tests/login.cy.ts
@@ -1,8 +1,10 @@
 import { api } from 'cypress/support/api';
+import { accounts } from 'cypress/fixtures/accounts';
 import { v4 as uuidv4 } from 'uuid';
 
 describe('login', () => {
   const username = `login-${uuidv4()}`;
+  const menteeWithoutEmail = accounts.mentees[3];
 
   const testErrorVisible = () => {
     cy.get('[id="login-error"]').should('be.visible');
@@ -13,7 +15,9 @@ describe('login', () => {
   };
 
   before(() => {
+    api.deleteAccounts();
     cy.registerUser(username, 'examplePassword');
+    api.signUpMentee(menteeWithoutEmail);
   });
 
   beforeEach(() => {
@@ -68,6 +72,14 @@ describe('login', () => {
   it('can log in with registered account', () => {
     cy.fillInput('username', username);
     cy.fillInput('password', 'examplePassword');
+    clickLogin();
+    cy.location('pathname').should('eq', '/');
+    cy.contains('Kirjaudu ulos').should('be.visible');
+  });
+
+  it('can log in with user that does not have email-address', () => {
+    cy.fillInput('username', menteeWithoutEmail.loginName);
+    cy.fillInput('password', menteeWithoutEmail.password);
     clickLogin();
     cy.location('pathname').should('eq', '/');
     cy.contains('Kirjaudu ulos').should('be.visible');

--- a/cypress/tests/mentee.cy.ts
+++ b/cypress/tests/mentee.cy.ts
@@ -29,7 +29,7 @@ describe('mentee profile', () => {
     cy.getByText('Tilin tiedot', 'h2').should('be.visible');
     cy.getByText('Käyttäjä', 'p').should('be.visible');
     cy.getByText(mentee.loginName, 'p').should('be.visible');
-    cy.getByText(mentee.email, 'p').should('be.visible');
+    cy.getByText(String(mentee?.email), 'p').should('be.visible');
 
     cy.getByText('Julkiset tiedot', 'h2').should('be.visible');
     cy.getByText(mentee.displayName, 'p').should('be.visible');

--- a/src/features/Authentication/models.ts
+++ b/src/features/Authentication/models.ts
@@ -14,13 +14,18 @@ const userCodec = D.struct({
   role: role,
 });
 
-const accountCodec = D.struct({
+const accountMandatory = D.struct({
   active: D.boolean,
-  email: D.string,
   id: D.string,
   login_name: D.string,
   role: role,
 });
+
+const accountOptional = D.partial({
+  email: D.string,
+});
+
+const accountCodec = pipe(accountMandatory, D.intersect(accountOptional));
 
 const commonResponse = D.struct({
   account: accountCodec,

--- a/src/features/ProfilePage/components/EmailEditor.tsx
+++ b/src/features/ProfilePage/components/EmailEditor.tsx
@@ -18,7 +18,7 @@ const EmailEditor = () => {
   const account = useAppSelector(selectAccount);
   const [updateAccount, { isLoading }] = useUpdateAccountMutation();
 
-  const [email, setEmail] = useState(account.email);
+  const [email, setEmail] = useState(String(account.email));
   const [isOpen, setIsOpen] = useState(false);
   const toggleIsOpen = () => setIsOpen(!isOpen);
 


### PR DESCRIPTION
# Description

With old-old users, it is possible that the email-property is missing. Make the codec similar than in [moblle-app](https://github.com/sos-lapsikyla/ylitse-app/blob/master/src/api/account.ts)


Fixes # ([issue](https://trello.com/c/PwOayr5J/1094-make-email-optional-in-account-schema))

## Why was the change made?

For example, the old admin-user was not able to login to web

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unittest
- [ ] Cypress e2e -tests

# Caveats?

Does this introduce new warnings or are linter rules suppressed? Why? Is only manual testing applicable for this feature? Is there something special that the reviewer should take into account?

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
