### PR TITLE
Show api-version from version endpoint

### DIFF
--- a/src/baseApi.ts
+++ b/src/baseApi.ts
@@ -4,6 +4,6 @@ import { refreshingBaseQuery } from '@/utils/http';
 export const baseApi = createApi({
   baseQuery: refreshingBaseQuery,
   reducerPath: 'api',
-  tagTypes: ['mentors', 'myuser'],
+  tagTypes: ['mentors', 'myuser', 'apiversion'],
   endpoints: () => ({}),
 });

--- a/src/components/Text/variants.ts
+++ b/src/components/Text/variants.ts
@@ -138,6 +138,16 @@ export const variants = {
       lineHeight: '3rem',
     },
   },
+  span: {
+    element: 'span',
+    styles: {
+      fontFamily: '"Baloo 2"',
+      fontSize: '1rem',
+      fontStyle: 'normal',
+      fontWeight: 700,
+      lineHeight: '3rem',
+    },
+  },
   logo: {
     element: 'p',
     styles: {

--- a/src/features/About/apiVersionApi.ts
+++ b/src/features/About/apiVersionApi.ts
@@ -1,0 +1,24 @@
+import { baseApi } from '@/baseApi';
+import { parseAndTransformTo } from '@/utils/http';
+
+import * as D from 'io-ts/Decoder';
+
+const apiVersion = D.struct({ api: D.string });
+
+export const apiVersionApi = baseApi.injectEndpoints({
+  endpoints: builder => ({
+    getApiVersion: builder.query<string, void>({
+      query: () => 'version',
+      providesTags: ['apiversion'],
+      transformResponse: (response: unknown) =>
+        parseAndTransformTo(
+          response,
+          apiVersion,
+          { api: '' },
+          response => response.api,
+        ),
+    }),
+  }),
+});
+
+export const { useGetApiVersionQuery } = apiVersionApi;

--- a/src/features/About/index.tsx
+++ b/src/features/About/index.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 
 import { useEscape } from '@/hooks/useEscape';
 import { useGetLayoutMode } from '@/hooks/useGetLayoutMode';
+import { useGetApiVersionQuery } from './apiVersionApi';
 
 import { breakpoints, palette } from '@/components/constants';
 import { Text } from '@/components/Text/Text';
@@ -23,6 +24,9 @@ export const About = ({ onDismiss }: Props) => {
   const toggleLicenseModal = () =>
     setIsLicenseModalVisible(!isLicenseModalVisible);
 
+  const { data: apiVersion } = useGetApiVersionQuery();
+  const uiVersion = `${version.version}+git:${COMMIT_HASH}`;
+
   useEscape(() => onDismiss());
 
   return (
@@ -42,10 +46,8 @@ export const About = ({ onDismiss }: Props) => {
             <InfoText variant="p">{t('about.description.paragraph2')}</InfoText>
             <InfoText variant="p">{t('about.description.paragraph3')}</InfoText>
           </Description>
-          <InfoText variant="p">
-            {t('about.ui')} {version.version}+git:{COMMIT_HASH}
-          </InfoText>
-          <InfoText variant="p">{t('about.api')} </InfoText>
+          <InfoText variant="p">{t('about.ui', { uiVersion })}</InfoText>
+          <InfoText variant="p">{t('about.api', { apiVersion })} </InfoText>
           {isLicenseModalVisible && <LicenseModal />}
           <LicensesButton onClick={toggleLicenseModal}>
             {!isLicenseModalVisible ? t('about.open') : t('about.close')}

--- a/src/features/HomePage/components/ProfileWidget.tsx
+++ b/src/features/HomePage/components/ProfileWidget.tsx
@@ -41,7 +41,7 @@ const ProfileWidget: React.FC<Props> = ({
       <Text variant="p">
         {t('profileWidget.text')}
         <Link to="/profile">
-          <Text variant="link" color="purple">
+          <Text variant="span" color="purple">
             {t('profileWidget.link')}
           </Text>
         </Link>

--- a/src/features/Navigation/InfoDropdown/InfoItem.tsx
+++ b/src/features/Navigation/InfoDropdown/InfoItem.tsx
@@ -14,7 +14,7 @@ export const InfoItem = ({ text, url }: NavigationItem) => (
       rel="noreferrer"
       style={{ textDecoration: 'none' }}
     >
-      <Text variant="link" color="purple">
+      <Text variant="span" color="purple">
         {text}
       </Text>
     </a>

--- a/src/static/locales/en/common.json
+++ b/src/static/locales/en/common.json
@@ -9,8 +9,8 @@
     "licenses": "Licenses",
     "open": "Open licenses",
     "close": "Close licenses",
-    "ui": "UI Version",
-    "api": "API Version 2.0",
+    "ui": "UI Version: {{uiVersion}}",
+    "api": "API Version: {{apiVersion}}",
     "noFile": "No licenses.json file found"
   },
   "footer": "Provided by",

--- a/src/static/locales/fi/common.json
+++ b/src/static/locales/fi/common.json
@@ -9,8 +9,8 @@
     "licenses": "Lisenssit",
     "open": "Avaa lisenssit",
     "close": "Sulje lisenssit",
-    "ui": "UI Version",
-    "api": "API Version 2.0",
+    "ui": "UI Version: {{uiVersion}}",
+    "api": "API Version: {{apiVersion}}",
     "noFile": "Lisenssitiedostoa ei löytynyt"
   },
   "footer": "Palvelun tarjoaa",


### PR DESCRIPTION
# Description

Use API - version-endpoint to show the version of API

- Also additional fix, use spans inside a-elements, since if we nest a:s its not correct and we get annoying console-warning.

Fixes # ([issue](https://trello.com/c/1a5eDAOO/1090-use-api-version-on-about-modal))

## Why was the change made?

Before we just show "2.0"

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unittest
- [ ] Cypress e2e -tests

# Caveats?

Does this introduce new warnings or are linter rules suppressed? Why? Is only manual testing applicable for this feature? Is there something special that the reviewer should take into account?

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
