### PR TITLE
1007 - Closing the info navigation when link modal is opened

### DIFF
--- a/src/features/Navigation/InfoDropdown/index.tsx
+++ b/src/features/Navigation/InfoDropdown/index.tsx
@@ -15,7 +15,6 @@ const InfoDropdown = () => {
     useComponentVisible<HTMLDivElement>(false);
   const { t } = useTranslation('common');
   const [isAboutVisible, setIsAboutVisible] = useState(false);
-  const toggleAbout = () => setIsAboutVisible(!isAboutVisible);
 
   return (
     <Anchor ref={ref}>
@@ -28,25 +27,26 @@ const InfoDropdown = () => {
       {isComponentVisible && (
         <Menu>
           <InfoItem
-            {...{
-              text: t('navigation.info.link.feedback.text'),
-              url: links.ylitseFeedbackUrl,
-            }}
+            text={t('navigation.info.link.feedback.text')}
+            url={links.ylitseFeedbackUrl}
           />
           <InfoItem
-            {...{
-              text: t('navigation.info.link.termsAndPrivacy.text'),
-              url: links.ylitseTermsUrl,
-            }}
+            text={t('navigation.info.link.termsAndPrivacy.text')}
+            url={links.ylitseTermsUrl}
           />
-          <Container onClick={toggleAbout}>
+          <Container
+            onClick={() => {
+              setIsComponentVisible(false);
+              setIsAboutVisible(true);
+            }}
+          >
             <Text variant="link" color="purple">
               {t('navigation.info.applicationInfo')}
             </Text>
           </Container>
         </Menu>
       )}
-      {isAboutVisible && <About onDismiss={toggleAbout} />}
+      {isAboutVisible && <About onDismiss={() => setIsAboutVisible(false)} />}
     </Anchor>
   );
 };


### PR DESCRIPTION
# Description

The info dropdown menu did not close when a sub-menu item was clicked. Changed so that the menu is closed when the item is clicked.

Fixes # 1007
[https://trello.com/c/EDAU1uQ7/1007-closing-a-modal-will-leave-navigation-menu-open](https://trello.com/c/EDAU1uQ7/1007-closing-a-modal-will-leave-navigation-menu-open)

## Why was the change made?

The menu dropdown was still open after an item had been clicked and the focus was moved to modal that had been opened

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unittest
- [ ] Cypress e2e -tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
