### PR TITLE
1089 - Chat bubble spacing fix

### DIFF
--- a/src/features/Chat/components/ActiveWindow/Message.tsx
+++ b/src/features/Chat/components/ActiveWindow/Message.tsx
@@ -61,6 +61,7 @@ const Container = styled.div<{ isSent: boolean; isVisible: boolean }>`
   align-items: ${({ isSent }) => (isSent ? 'flex-end' : 'flex-start')};
   display: flex;
   flex-direction: column;
+  margin-bottom: 8px;
 `;
 
 const Bubble = styled.div<{
@@ -81,8 +82,7 @@ const Content = styled(Text)`
 `;
 
 const Timestamp = styled(Text)<{ isSent: boolean }>`
+  margin: 0;
   ${({ isSent }) => (isSent ? 'margin-right: 14px;' : 'margin-left: 14px;')}
-  margin-bottom: 0;
-  margin-top: 0;
   text-align: right;
 `;


### PR DESCRIPTION
# Description

Chat bubbles were too close to each other so I added some bottom margin to the containers.

Fixes # 1089
https://trello.com/c/MGf0ErhT/1089-message-bubbles-too-close-to-each-other

## Why was the change made?

To separate the chat bubbles and make it clearer what message the timestamps were part of

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Visually tested that the margins were there

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
