### PR TITLE
1025 - Notification styles fixes

### DIFF
--- a/src/features/Confirmation/ButtonGroup.tsx
+++ b/src/features/Confirmation/ButtonGroup.tsx
@@ -37,6 +37,7 @@ const ButtonContainer = styled.div`
   display: flex;
   gap: 1.75rem;
   justify-content: center;
+  margin-top: 2rem;
 `;
 
 export default ButtonGroup;

--- a/src/features/Confirmation/Dialog.tsx
+++ b/src/features/Confirmation/Dialog.tsx
@@ -136,7 +136,7 @@ const Container = styled.div`
   box-sizing: border-box;
   display: flex;
   flex-direction: row;
-  height: 250px;
+  height: auto;
   left: 50%;
   position: absolute;
   top: 50%;

--- a/src/features/Confirmation/Dialog.tsx
+++ b/src/features/Confirmation/Dialog.tsx
@@ -162,6 +162,7 @@ const Icon = styled.img`
 
 const Content = styled.div`
   padding: 2rem 3rem;
+  width: 100%;
 `;
 
 const CloseButton = styled(IconButton)`


### PR DESCRIPTION
# Description

The notification dialog styling was different between the report user and archive dialogs. The button alignment was depending on the contents text length and row count. Also the dialogs height was fixed so it did not grow depending on the amount of text.

Fixes # 1025
https://trello.com/c/PjI9rKUy/1025-fix-notification-styles

## Why was the change made?

What is the motivation for this change?

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unittest
- [ ] Cypress e2e -tests

# Caveats?

Does this introduce new warnings or are linter rules suppressed? Why? Is only manual testing applicable for this feature? Is there something special that the reviewer should take into account?

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
