### PR TITLE
Add scrolling follower if already on bottom

### DIFF
--- a/src/features/Chat/components/ActiveWindow/ScrollToBottomButton/useBottomAction.ts
+++ b/src/features/Chat/components/ActiveWindow/ScrollToBottomButton/useBottomAction.ts
@@ -26,7 +26,6 @@ export const useBottomAction = (
 
     const parent = parentRef.current;
     parent?.addEventListener('scroll', updatePosition);
-
     window.addEventListener('resize', updatePosition);
 
     return () => {
@@ -38,6 +37,21 @@ export const useBottomAction = (
   useEffect(() => {
     handleBottomActionClick();
   }, []);
+
+  // Watch for changes in the content of the parentRef div
+  useEffect(() => {
+    if (!parentRef.current) return;
+
+    const observer = new MutationObserver(() => {
+      if (isScrolled) {
+        handleBottomActionClick();
+      }
+    });
+
+    observer.observe(parentRef.current, { childList: true, subtree: true });
+
+    return () => observer.disconnect();
+  }, [isScrolled, parentRef]);
 
   const handleBottomActionClick = () => {
     if (parentRef.current) {


### PR DESCRIPTION
# Description

Improve chat scrolling behaviour:
1. if a new message appears and user is on the bottom, there will be automatic scroll
2. Another scenario: We have scrolled to the middle of the content. If new message appears, we dont automatically scroll to the bottom.

Fixes # ([issue](https://trello.com/c/LpZr0ja5/1064-chat-does-not-scroll-to-the-newest-message))

## Screencap

The video demonstrates this fix maybe better than my writing.

You can also see the scroll-to-bottom-button briefly flashing on the messages list when a new message appears and the auto-scroll takes effect.
That I'll fix too, but just atm I don't have a nice idea how to fix it, so I need to sleep on it.

https://github.com/user-attachments/assets/c698865f-6bcf-419c-943d-4eaa967760dc

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unittest
- [ ] Cypress e2e -tests

# Caveats?

Does this introduce new warnings or are linter rules suppressed? Why? Is only manual testing applicable for this feature? Is there something special that the reviewer should take into account?

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
