### PR TITLE
Showing info component for mentors

### DIFF
--- a/cypress/tests/home.cy.ts
+++ b/cypress/tests/home.cy.ts
@@ -122,7 +122,7 @@ describe('home', () => {
     api.signUpMentor(mentor);
     cy.loginUser(mentor.loginName, mentor.password);
 
-    cy.getByText('Aloita etsimällä mentori', 'h2').should('be.visible');
+    cy.getByText('Tukea ja seuraa', 'h1').should('be.visible');
 
     cy.getByText(`Tervetuloa, ${mentor.displayName}`, 'p').should('be.visible');
 
@@ -162,7 +162,7 @@ describe('home', () => {
 
     cy.loginUser(mentor.loginName, mentor.password);
 
-    cy.getByText('Aloita etsimällä mentori', 'h2').should('be.visible');
+    cy.getByText('Tukea ja seuraa', 'h1').should('be.visible');
 
     cy.getByText('Keskustele aktoreiden kanssa', 'h2').should('not.exist');
     cy.getByText('Sinulla on lukemattomia viestejä', 'h2').should('be.visible');
@@ -218,7 +218,7 @@ describe('home', () => {
 
     cy.loginUser(mentor.loginName, mentor.password);
 
-    cy.getByText('Aloita etsimällä mentori', 'h2').should('be.visible');
+    cy.getByText('Tukea ja seuraa', 'h1').should('be.visible');
 
     cy.getByText('Sinulla on lukemattomia viestejä', 'h2').should('not.exist');
     cy.getByText('Keskustele aktoreiden kanssa', 'h2').should('be.visible');
@@ -269,7 +269,7 @@ describe('home', () => {
 
     cy.loginUser(mentor.loginName, mentor.password);
 
-    cy.getByText('Aloita etsimällä mentori', 'h2').should('be.visible');
+    cy.getByText('Tukea ja seuraa', 'h1').should('be.visible');
 
     cy.getByText('Sinulla on lukemattomia viestejä', 'h2').should('not.exist');
     cy.getByText('Keskustele aktoreiden kanssa', 'h2').should('be.visible');

--- a/src/features/HomePage/index.tsx
+++ b/src/features/HomePage/index.tsx
@@ -42,7 +42,7 @@ const HomePage = () => {
   ) : (
     <>
       <TopContainer>
-        <SkillQuickFilter />
+        {mentor ? <Info /> : <SkillQuickFilter />}
         <WelcomeMessage />
       </TopContainer>
       <MiddleContainer>


### PR DESCRIPTION
# Description

- Adds check so that Info-component is shown for mentors and SkillQuickFilter for all others (mentee and admin)

Fixes # ([1279](https://trello.com/c/B3uYCqyr/1279-quick-skill-filter-improvements))

## Why was the change made?

What is the motivation for this change?

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unittest
- [ ] Cypress e2e -tests

# Caveats?

Does this introduce new warnings or are linter rules suppressed? Why? Is only manual testing applicable for this feature? Is there something special that the reviewer should take into account?

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
